### PR TITLE
Make MAC addresses build-time configurable

### DIFF
--- a/examples/kitty/Makefile
+++ b/examples/kitty/Makefile
@@ -9,13 +9,21 @@ $(error MICROKIT_SDK must be specified)
 endif
 
 ifeq ($(strip $(LIBGCC)),)
-$(error LIBGCC must be specified: this should be the directory where libgcc.a can be found)
+LIBGCC := $(shell dirname $$(aarch64-none-elf-gcc --print-file-name libgcc.a))
 endif
 
 MICROKIT_CONFIG ?= debug
 BUILD_DIR ?= $(abspath build)
 MICROKIT_BOARD := odroidc4
 CPU := cortex-a55
+
+# '?=' means the variable is regenerated every time the macros is invoked.
+# Get one value once, and use that (':=')
+# If we've buit part of the system with a MAC address, use that and
+# don't geneate a new one
+-include ${BUILD_DIR}/mac_address
+XMAC_BASE_ADDRESS ?= $(shell < /dev/urandom tr -d -c '[:digit:]A-F' | fold -w12 | sed -E -n -e '/^.[26AE]/s/^/0x/' -e '/0x/{s/$$/ULL/;p;q}')
+export MAC_BASE_ADDRESS := ${XMAC_BASE_ADDRESS}
 
 TOOLCHAIN := clang
 CC := clang
@@ -54,7 +62,9 @@ CFLAGS := \
 	-I$(LIBVMM)/src \
 	-I$(LIBVMM)/src/util \
 	-DBOARD_$(MICROKIT_BOARD) \
-	-I$(SDDF)/include
+	-I$(SDDF)/include \
+	-DMAC_BASE_ADDRESS=$(MAC_BASE_ADDRESS)
+
 LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := -lmicrokit -Tmicrokit.ld
 
@@ -72,7 +82,7 @@ TIMER_DRIVER := $(SDDF)/drivers/clock/meson
 
 PACKAGE_PYTHON_SCRIPTS := src/package_python_scripts.S
 
-all: $(DIRECTORIES) $(BUILD_DIR) $(IMAGE_FILE)
+all: $(DIRECTORIES) $(BUILD_DIR) $(IMAGE_FILE) 
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
@@ -82,6 +92,9 @@ $(BUILD_DIR)/%.o: src/%.c
 
 $(BUILD_DIR)/%.o: src/vmm/%.c
 	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILD_DIR)/mac_address: ${BUILD_DIR}
+	echo "XMAC_BASE_ADDRESS=${MAC_BASE_ADDRESS}" > $@
 
 $(BUILD_DIR)/timer.o: $(TIMER_DRIVER)/timer.c
 	$(CC) -c $(CFLAGS) $< -o $@
@@ -202,6 +215,7 @@ NETWORK_COMPONENT_CFLAGS := \
 	-Wno-unused-function \
 	-DNO_ASSERT \
 	-DBOARD_$(MICROKIT_BOARD) \
+	-DMAC_BASE_ADDRESS=$(MAC_BASE_ADDRESS) \
 	-MD \
 	-MP
 

--- a/fs/nfs/Makefile
+++ b/fs/nfs/Makefile
@@ -24,6 +24,10 @@ ifeq ($(strip $(NFS_DIRECTORY)),)
 $(error NFS_DIRECTORY must be specified)
 endif
 
+ifeq ($(strip $MAC_BASE_ADDRESS)),)
+$(error MAC_BASE ADDRESS must be specified)
+endif
+
 BUILD_DIR ?= .
 
 TOOLCHAIN := aarch64-none-elf
@@ -53,7 +57,8 @@ DEFINE := \
 	-DETHERNET_RX_CHANNEL=2 \
 	-DETHERNET_ARP_CHANNEL=11 \
 	-DTIMER_CHANNEL=9 \
-	-DCLIENT_CHANNEL=7
+	-DCLIENT_CHANNEL=7 \
+	-DMAC_BASE_ADDRESS=${MAC_BASE_ADDRESS}
 
 CFLAGS := $(INCLUDE) $(DEFINE) \
 	-mstrict-align \

--- a/fs/nfs/tcp.c
+++ b/fs/nfs/tcp.c
@@ -30,6 +30,16 @@
 #define NUM_BUFFERS 512
 #define BUF_SIZE 2048
 
+#ifndef MAC_BASE_ADDRESS
+#  define MAC_BASE_ADDRESS (0x525401000000ULL)
+#endif
+
+/*
+ * The same base MAC address is used by all components;
+ * each component has a different offset to add to the least significant byte
+ */
+#define MAC_OFFSET (10)
+
 typedef struct state
 {
     struct netif netif;
@@ -171,12 +181,11 @@ uint32_t sys_now(void) {
 }
 
 static void get_mac(void) {
-    state.mac[0] = 0x52;
-    state.mac[1] = 0x54;
-    state.mac[2] = 0x1;
-    state.mac[3] = 0;
-    state.mac[4] = 0;
-    state.mac[5] = 10;
+    int i;
+    for (i = 5; i >= 0; --i) {
+        state.mac[5 - i] = 0xff & (MAC_BASE_ADDRESS >> (i*8));
+    }
+    state.mac[5] += MAC_OFFSET;
 }
 
 static void netif_status_callback(struct netif *netif) {


### PR DESCRIPTION
The Makefile will now generate a random MAC address range to use for all components.  Individual components add an offset to the base MAC address

The Makefile saves the MAC address it uses and reuses the same one if it finds a saved one, so rerunning make does not change the MAC address unless you delete the build tree.

This relies on the corresponding changes to the sDDF repo.