### PR TITLE
Fix timer conversion issue in NFS client

### DIFF
--- a/fs/nfs/tcp.c
+++ b/fs/nfs/tcp.c
@@ -165,9 +165,8 @@ cleanCache(unsigned long start, unsigned long end)
     }
 }
 
-
 uint32_t sys_now(void) {
-    return sddf_timer_time_now() * US_IN_MS;
+    return sddf_timer_time_now() / NS_IN_MS;
 }
 
 static void get_mac(void) {


### PR DESCRIPTION
The Odroid-C4 timer driver returns nanoseconds for the current time and sys_now should be returning milliseconds so we should be *dividing* by 1,000,000.

Fix found by Courtney Darville (@Courtney3141), credit goes to her. Am upstreaming this now since it's blocking multiple people working on LionsOS.