### PR TITLE
kitty: pass absolute path of build directory

### DIFF
--- a/examples/kitty/Makefile
+++ b/examples/kitty/Makefile
@@ -138,7 +138,7 @@ $(BUILD_DIR)/micropython.elf: FORCE mpy-cross $(BUILD_DIR)/sddf_timer_client.o $
 			MICROKIT_BOARD=$(MICROKIT_BOARD) \
 			MICROKIT_CONFIG=$(MICROKIT_CONFIG) \
 			BUILD=$(abspath $(BUILD_DIR)) \
-			LIBMATH=$(BUILD_DIR)/libm \
+			LIBMATH=$(abspath $(BUILD_DIR)/libm) \
 			ETHERNET_CONFIG_INCLUDE=$(abspath $(ETHERNET_CONFIG_INCLUDE))
 
 ETHERNET=$(SDDF)/drivers/network/meson/


### PR DESCRIPTION
The default build directory is an absolute path but we forgot about the case where the environment specifies the build dir.