### PR TITLE
micropython: don't use printf 'h' format specifiers

### DIFF
--- a/components/micropython/lwip_include/arch/cc.h
+++ b/components/micropython/lwip_include/arch/cc.h
@@ -21,9 +21,9 @@ typedef int64_t  s64_t;
 typedef uintptr_t mem_ptr_t;
 
 
-#define U16_F "hu"
+#define U16_F "u"
 #define S16_F "d"
-#define X16_F "hx"
+#define X16_F "x"
 #define U32_F "u"
 #define S32_F "d"
 #define X32_F "x"


### PR DESCRIPTION
The MicroPython component uses lwIP for its socket implementation. lwIP in turn makes use of the printf provided by MicroPython. MicroPython's printf does not support the 'h' specifiers, like %hu or %hx. As such, lwIP must not call printf with these specifiers. lwIP's usage of these specifiers can be configured via the U16_F and X16_F constants in lwip_include/arch/cc.h. This commit changes those constants to use %u and %x instead of %hu and %hx.