### PR TITLE
examples: always compile with optimisations

### DIFF
--- a/examples/kitty/kitty.mk
+++ b/examples/kitty/kitty.mk
@@ -69,7 +69,7 @@ CFLAGS := \
 	-mstrict-align \
 	-ffreestanding \
 	-g \
-	-O0 \
+	-O2 \
 	-Wall \
 	-Wno-unused-function \
 	-I$(BOARD_DIR)/include \

--- a/examples/vmm/vmm-dev.mk
+++ b/examples/vmm/vmm-dev.mk
@@ -55,7 +55,7 @@ CFLAGS := \
 	-mstrict-align \
 	-ffreestanding \
 	-g \
-	-O0 \
+	-O2 \
 	-Wall \
 	-Wno-unused-function \
 	-I. \

--- a/examples/vmm/vmm-virtio-console.mk
+++ b/examples/vmm/vmm-virtio-console.mk
@@ -61,7 +61,7 @@ CFLAGS := \
 	-mstrict-align \
 	-ffreestanding \
 	-g \
-	-O0 \
+	-O2 \
 	-Wall \
 	-Wno-unused-function \
 	-I. \

--- a/examples/webserver/webserver.mk
+++ b/examples/webserver/webserver.mk
@@ -47,7 +47,7 @@ CFLAGS := \
 	-mtune=$(CPU) \
 	-mstrict-align \
 	-ffreestanding \
-	-O3 \
+	-O2 \
 	-MD \
 	-MP \
 	-Wall \


### PR DESCRIPTION
There's no reason to my knowledge to always compile without optimisations.

Note that I haven't tested the Kitty or web server example which should be done before merging this.