### PR TITLE
examples/kitty: fetch images at build time

### DIFF
--- a/ci/kitty.sh
+++ b/ci/kitty.sh
@@ -24,5 +24,6 @@ export LIONSOS=$LIONSOS
 
 cd $LIONSOS/examples/kitty
 make submodules
+make images
 make
 

--- a/examples/kitty/Makefile
+++ b/examples/kitty/Makefile
@@ -29,6 +29,9 @@ export BUILD_DIR ?= $(abspath build)
 export MICROKIT_BOARD := odroidc4
 export CPU := cortex-a55
 
+KITTY_GRAPHICS_VM_ROOTFS := 08c10529dc2806559d5c4b7175686a8206e10494-rootfs.cpio.gz
+KITTY_GRAPHICS_VM_LINUX := 90c4247bcd24cbca1a3db4b7489a835ce87a486e-linux
+
 IMAGE_FILE := $(BUILD_DIR)/kitty.img
 REPORT_FILE := $(BUILD_DIR)/report.txt
 
@@ -41,6 +44,10 @@ ${BUILD_DIR}/Makefile: kitty.mk
 	mkdir -p ${BUILD_DIR}
 	cp kitty.mk $@
 
+images:
+	mkdir -p ${BUILD_DIR}
+	cd ${BUILD_DIR} && curl -L https://lionsos.org/downloads/examples/kitty/$(KITTY_GRAPHICS_VM_ROOTFS) -o rootfs.cpio.gz
+	cd ${BUILD_DIR} && curl -L https://lionsos.org/downloads/examples/kitty/$(KITTY_GRAPHICS_VM_LINUX) -o linux
 
 submodules:
 	git submodule update --init $(LIONSOS)/dep/libvmm

--- a/examples/kitty/kitty.mk
+++ b/examples/kitty/kitty.mk
@@ -19,8 +19,8 @@ SDDF := $(LIONSOS)/dep/sddf
 LIBVMM_DIR := $(LIONSOS)/dep/libvmm
 
 VMM_IMAGE_DIR := ${KITTY_DIR}/src/vmm/images
-LINUX := $(VMM_IMAGE_DIR)/linux
-INITRD := $(VMM_IMAGE_DIR)/rootfs.cpio.gz
+LINUX := $(abspath linux)
+INITRD := $(abspath rootfs.cpio.gz)
 DTS := $(VMM_IMAGE_DIR)/linux.dts
 DTB := linux.dtb
 


### PR DESCRIPTION
We no longer check in the images into the repository, so we have an extra `make images` step to fetch them first before calling `make`.

There are probably improvements to be made about how this works in the case you delete your build directory etc.