### PR TITLE
examples: increase NFS client's stack size

### DIFF
--- a/examples/kitty/kitty.system
+++ b/examples/kitty/kitty.system
@@ -207,7 +207,7 @@
         <map mr="serial_rx_data_micropython" vaddr="0x4_004_000" perms="rw" cached="true" setvar_vaddr="rx_data_cli0" />
     </protection_domain>
 
-    <protection_domain name="nfs" priority="98">
+    <protection_domain name="nfs" priority="98" stack_size="0x10000">
         <program_image path="nfs.elf" />
         <map mr="eth_rx_free_nfs" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
         <map mr="eth_rx_active_nfs" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />

--- a/examples/webserver/webserver.system
+++ b/examples/webserver/webserver.system
@@ -151,7 +151,7 @@
         <map mr="serial_tx_data_nfs" vaddr="0x4_009_000" perms="r" cached="true"/>
     </protection_domain>
 
-    <protection_domain name="nfs" priority="98">
+    <protection_domain name="nfs" priority="98" stack_size="0x10000">
         <program_image path="nfs.elf" />
         <map mr="eth_rx_free_nfs" vaddr="0x2_000_000" perms="rw" cached="true" setvar_vaddr="rx_free" />
         <map mr="eth_rx_active_nfs" vaddr="0x2_200_000" perms="rw" cached="true" setvar_vaddr="rx_active" />


### PR DESCRIPTION
We have found that when doing certain operations with the NFS client that it would run out of stack size. 16KiB has been sufficient in our testing.