### PR TITLE
kitty: make vm images explicit dependencies

### DIFF
--- a/ci/kitty.sh
+++ b/ci/kitty.sh
@@ -24,6 +24,5 @@ export LIONSOS=$LIONSOS
 
 cd $LIONSOS/examples/kitty
 make submodules
-make images
 make
 

--- a/examples/kitty/Makefile
+++ b/examples/kitty/Makefile
@@ -29,9 +29,6 @@ export BUILD_DIR ?= $(abspath build)
 export MICROKIT_BOARD := odroidc4
 export CPU := cortex-a55
 
-KITTY_GRAPHICS_VM_ROOTFS := 08c10529dc2806559d5c4b7175686a8206e10494-rootfs.cpio.gz
-KITTY_GRAPHICS_VM_LINUX := 90c4247bcd24cbca1a3db4b7489a835ce87a486e-linux
-
 IMAGE_FILE := $(BUILD_DIR)/kitty.img
 REPORT_FILE := $(BUILD_DIR)/report.txt
 
@@ -43,11 +40,6 @@ qemu ${IMAGE_FILE} ${REPORT_FILE} clean clobber: ${BUILD_DIR}/Makefile FORCE
 ${BUILD_DIR}/Makefile: kitty.mk
 	mkdir -p ${BUILD_DIR}
 	cp kitty.mk $@
-
-images:
-	mkdir -p ${BUILD_DIR}
-	cd ${BUILD_DIR} && curl -L https://lionsos.org/downloads/examples/kitty/$(KITTY_GRAPHICS_VM_ROOTFS) -o rootfs.cpio.gz
-	cd ${BUILD_DIR} && curl -L https://lionsos.org/downloads/examples/kitty/$(KITTY_GRAPHICS_VM_LINUX) -o linux
 
 submodules:
 	git submodule update --init $(LIONSOS)/dep/libvmm

--- a/examples/kitty/kitty.mk
+++ b/examples/kitty/kitty.mk
@@ -19,8 +19,8 @@ SDDF := $(LIONSOS)/dep/sddf
 LIBVMM_DIR := $(LIONSOS)/dep/libvmm
 
 VMM_IMAGE_DIR := ${KITTY_DIR}/src/vmm/images
-LINUX := $(abspath linux)
-INITRD := $(abspath rootfs.cpio.gz)
+LINUX := 90c4247bcd24cbca1a3db4b7489a835ce87a486e-linux
+INITRD := 08c10529dc2806559d5c4b7175686a8206e10494-rootfs.cpio.gz
 DTS := $(VMM_IMAGE_DIR)/linux.dts
 DTB := linux.dtb
 
@@ -91,6 +91,9 @@ include ${SDDF}/libco/libco.mk
 # Build the VMM for graphics
 VMM_OBJS := vmm.o package_guest_images.o
 VPATH := ${LIBVMM_DIR}:${VMM_IMAGE_DIR}:${VMM_IMAGE_DIR}/..
+
+$(INITRD) $(LINUX):
+	curl -L https://lionsos.org/downloads/examples/kitty/$@ -o $@
 
 $(DTB): $(DTS)
 	$(DTC) -q -I dts -O dtb $< > $@


### PR DESCRIPTION
This removes the "make images" build step and allows make to download the images automatically when required.