### PR TITLE
EXEC_MODULE for micropython needs module name, not path

### DIFF
--- a/examples/webserver/webserver.mk
+++ b/examples/webserver/webserver.mk
@@ -85,7 +85,7 @@ micropython.elf: mpy-cross manifest.py webserver.py config.py \
 			LIBMATH=$(abspath $(BUILD_DIR)/libm) \
 			CONFIG_INCLUDE=$(abspath $(CONFIG_INCLUDE)) \
 			FROZEN_MANIFEST=$(abspath ./manifest.py) \
-			EXEC_MODULE=$(abspath ./webserver.py)
+			EXEC_MODULE=webserver.py
 
 config.py: ${CHECK_FLAGS_BOARD_MD5}
 	echo "base_dir='$(WEBSITE_DIR)'" > config.py


### PR DESCRIPTION
Without this change, the micropython server cannot find the webserver module, as its name is given with respect to the build environment, not the running environment.