### PR TITLE
Change lwIP minimum warning level to serious

### DIFF
--- a/components/fs/nfs/lwip_include/lwipopts.h
+++ b/components/fs/nfs/lwip_include/lwipopts.h
@@ -63,7 +63,7 @@
 /* Debugging options */
 #define LWIP_DEBUG
 /* Change this to LWIP_DBG_LEVEL_ALL to see a trace */
-#define LWIP_DBG_MIN_LEVEL              LWIP_DBG_LEVEL_WARNING
+#define LWIP_DBG_MIN_LEVEL              LWIP_DBG_LEVEL_SERIOUS
 
 #define DHCP_DEBUG                      LWIP_DBG_ON
 #define UDP_DEBUG                       LWIP_DBG_ON

--- a/components/micropython/lwip_include/lwipopts.h
+++ b/components/micropython/lwip_include/lwipopts.h
@@ -66,7 +66,7 @@
 /* Debugging options */
 #define LWIP_DEBUG
 /* Change this to LWIP_DBG_LEVEL_ALL to see a trace */
-#define LWIP_DBG_MIN_LEVEL              LWIP_DBG_LEVEL_WARNING
+#define LWIP_DBG_MIN_LEVEL              LWIP_DBG_LEVEL_SERIOUS
 
 #define DHCP_DEBUG                      LWIP_DBG_ON
 #define UDP_DEBUG                       LWIP_DBG_ON


### PR DESCRIPTION
Gets rid of these kind of messages in the examples:
```
netif->hwaddr[5]==12 != reply_msg->chaddr[5]==13
netif->hwaddr[5]==12 != reply_msg->chaddr[5]==13
```

which are annoying and don't actually tell you what happened.

The message doesn't mean anything wrong happened and clutter the output.