### PR TITLE
Improve kitty responsiveness

### DIFF
--- a/components/micropython/Makefile
+++ b/components/micropython/Makefile
@@ -27,11 +27,11 @@ BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
 
 # Set CFLAGS and libraries.
 CFLAGS += \
+	-O2 \
 	-I. \
 	-Ilwip_include \
 	-I$(BUILD) \
 	-I$(TOP) \
-	-I$(SDDF) \
 	-I$(SDDF)/include \
 	-I$(BOARD_DIR)/include \
 	-I$(LIBMICROKITCO_PATH) \

--- a/examples/kitty/client/kitty.py
+++ b/examples/kitty/client/kitty.py
@@ -70,8 +70,7 @@ class KittyDisplay(framebuf.FrameBuffer):
 
     def show(self):
         fb.wait()
-        fb.machine_fb_send(self.buf, self.width, self.height)
-
+        fb.machine_fb_send(memoryview(self.buf), self.width, self.height)
 
 # Heartbeat to let the server know we still exist
 def heartbeat():


### PR DESCRIPTION
Compiling micropython with `-O2` optimisations enabled reduce the latency of drawing to the framebuffer by 400 ms to an average of 100 ms.  Also switching to using a memoryview of the micropython framebuffer byte array to reduce copies. 