### PR TITLE
mp: remove unused function

### DIFF
--- a/components/micropython/micropython.c
+++ b/components/micropython/micropython.c
@@ -69,23 +69,6 @@ void MP_WEAK __assert_func(const char *file, int line, const char *func, const c
 }
 #endif
 
-// @ivanv: I don't know if this the best way of doing this
-static void exec_str(const char *src, mp_parse_input_kind_t input_kind) {
-    nlr_buf_t nlr;
-    if (nlr_push(&nlr) == 0) {
-        // Compile, parse and execute the given string.
-        mp_lexer_t *lex = mp_lexer_new_from_str_len(MP_QSTR__lt_stdin_gt_, src, strlen(src), 0);
-        qstr source_name = lex->source_name;
-        mp_parse_tree_t parse_tree = mp_parse(lex, input_kind);
-        mp_obj_t module_fun = mp_compile(&parse_tree, source_name, true);
-        mp_call_function_0(module_fun);
-        nlr_pop();
-    } else {
-        // Uncaught exception: print it out.
-        mp_obj_print_exception(&mp_plat_print, (mp_obj_t)nlr.ret_val);
-    }
-}
-
 void t_mp_entrypoint(void) {
     printf("MP|INFO: initialising!\n");
 


### PR DESCRIPTION
Not needed anymore. We use the REPL when we want interaction, and EXEC_MODULE when we want a script to automatically run.