### PR TITLE
Fix directory website redirection

### DIFF
--- a/examples/webserver/webserver.py
+++ b/examples/webserver/webserver.py
@@ -127,7 +127,7 @@ async def resolve(relative_path):
         # exists, and we did not find any files with the name suffixed
         # by a standard extension, so redirect the client to the form
         # with appropriate trailing slash.
-        return 301, f'{relative_path}/', None
+        return 301, f'/{relative_path}/', None
 
     return 404, None, None
 


### PR DESCRIPTION
When a URL referred to a directory, the webserver is meant to redirect to one with a trailing slash.  However it was returning a relative path, so, for example, https://sel4.org/Foundation/Summit redirected to https://sel4.org/Foundation/Summit/Foundation/summit/

Make it an absolute path.