### PR TITLE
ci: use multiple threads when compiling examples

### DIFF
--- a/ci/fileio.sh
+++ b/ci/fileio.sh
@@ -33,7 +33,7 @@ build() {
     export LIONSOS=$LIONSOS
 
     cd $LIONSOS/examples/fileio
-    make
+    make -j$(nproc)
 }
 
 BOARDS=("maaxboard" "qemu_virt_aarch64")

--- a/ci/kitty.sh
+++ b/ci/kitty.sh
@@ -35,7 +35,7 @@ build() {
     export LIONSOS=$LIONSOS
 
     cd $LIONSOS/examples/kitty
-    make
+    make -j$(nproc)
 }
 
 BOARDS=("odroidc4" "qemu_virt_aarch64")

--- a/ci/vmm.sh
+++ b/ci/vmm.sh
@@ -25,4 +25,4 @@ export MICROKIT_SDK=$MICROKIT_SDK
 export LIONSOS=$LIONSOS
 
 cd $LIONSOS/examples/vmm
-make
+make -j$(nproc)

--- a/ci/webserver.sh
+++ b/ci/webserver.sh
@@ -36,7 +36,7 @@ build() {
     export LIONSOS=$LIONSOS
 
     cd $LIONSOS/examples/webserver
-    make
+    make -j$(nproc)
 }
 
 build "odroidc4" "debug"


### PR DESCRIPTION
CI is already taking now ~10 minutes which is too long when we only have 4 examples (we have to compile them in debug as well as release mode but still).