### PR TITLE
Libmicrokitco update

### DIFF
--- a/components/fs/fat/event.c
+++ b/components/fs/fat/event.c
@@ -134,19 +134,15 @@ void init(void) {
        This part of the code is for setting up the thread pool by
        assign stacks and size of the stack to the pool
     */
-    uint64_t stack[FAT_WORKER_THREAD_NUM];
-    stack[0] = worker_thread_stack_one;
-    stack[1] = worker_thread_stack_two;
-    stack[2] = worker_thread_stack_three;
-    stack[3] = worker_thread_stack_four;
+    stack_ptrs_arg_array_t costacks = {
+        worker_thread_stack_one,
+        worker_thread_stack_two,
+        worker_thread_stack_three,
+        worker_thread_stack_four
+    };
 
     // Init thread pool
-    microkit_cothread_init(&co_controller_mem,
-                            FAT_WORKER_THREAD_STACKSIZE,
-                            stack[0],
-                            stack[1],
-                            stack[2],
-                            stack[3]);
+    microkit_cothread_init(&co_controller_mem, FAT_WORKER_THREAD_STACKSIZE, costacks);
     for (uint32_t i = 0; i < (FAT_WORKER_THREAD_NUM + 1); i++) {
         microkit_cothread_semaphore_init(&sem[i]);
     }

--- a/components/micropython/micropython.c
+++ b/components/micropython/micropython.c
@@ -115,7 +115,8 @@ void init(void) {
     i2c_queue_handle = i2c_queue_init((i2c_queue_t *)i2c_request_region, (i2c_queue_t *)i2c_response_region);
 #endif
 
-    microkit_cothread_init(&co_controller_mem, MICROPY_STACK_SIZE, mp_stack);
+    stack_ptrs_arg_array_t costacks = { mp_stack };
+    microkit_cothread_init(&co_controller_mem, MICROPY_STACK_SIZE, costacks);
 
     if (microkit_cothread_spawn(t_mp_entrypoint, NULL) == LIBMICROKITCO_NULL_HANDLE) {
         printf("MP|ERROR: Cannot initialise Micropython cothread\n");


### PR DESCRIPTION
This PR changes how coroutine stack pointers are passed into libmicrokitco's init function. 

Previously it is a variadic function, this is susceptible to programmer error as it is easy to pass in less or more pointers than required and it is not trivial to check how many arguments a variadic function received.

Now it leverages the type system so that the compiler can caught issues statically.