### PR TITLE
various CI + flake fixes

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run examples script
-        run: nix develop -c bash -c './ci/examples.sh $(pwd) $MICROKIT_SDK'
+        run: nix develop --ignore-environment -c bash -c './ci/examples.sh $(pwd) $MICROKIT_SDK'
   build_examples_macos_aarch64_nix:
     name: Build example systems (macOS ARM64 via Nix)
     runs-on: [self-hosted, macos, ARM64]
@@ -69,4 +69,4 @@ jobs:
           git submodule foreach --recursive git clean -ffdx
           git submodule foreach --recursive git reset --hard
       - name: Run examples script
-        run: nix develop -c bash -c './ci/examples.sh $(pwd) $MICROKIT_SDK'
+        run: nix develop --ignore-environment -c bash -c './ci/examples.sh $(pwd) $MICROKIT_SDK'

--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -42,18 +42,18 @@ jobs:
         shell: bash
         env:
           PYTHON: ${{ github.workspace }}/venv/bin/python
-  # build_examples_linux_x86_64_nix:
-  #   name: Build example systems (Linux x86-64 via Nix)
-  #   runs-on: ubuntu-24.04
-  #   steps:
-  #     - name: Checkout LionsOS repository
-  #       uses: actions/checkout@v4
-  #     - name: Install Nix
-  #       uses: cachix/install-nix-action@v25
-  #       with:
-  #         nix_path: nixpkgs=channel:nixos-unstable
-  #     - name: Run examples script
-  #       run: nix develop -c bash -c './ci/examples.sh $(pwd) $MICROKIT_SDK'
+  build_examples_linux_x86_64_nix:
+    name: Build example systems (Linux x86-64 via Nix)
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout LionsOS repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Run examples script
+        run: nix develop -c bash -c './ci/examples.sh $(pwd) $MICROKIT_SDK'
   build_examples_macos_aarch64_nix:
     name: Build example systems (macOS ARM64 via Nix)
     runs-on: [self-hosted, macos, ARM64]

--- a/flake.nix
+++ b/flake.nix
@@ -68,9 +68,16 @@
                 gnumake
                 dosfstools
                 curl
+                which
                 unzip
+                # for shasum
+                perl
                 dtc
                 pythonTool
+                # for mypy-cross
+                gcc
+                # for musllibc
+                cmake
                 # for git-clang-format.
                 llvm.libclang.python
                 llvm.lld

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
             in
             # mkShellNoCC, because we do not want the cc from stdenv to leak into this shell
             pkgs.mkShellNoCC rec {
-              name = "sddf-dev";
+              name = "lionsos-dev";
 
               microkit-platform = microkit-platforms.${system} or (throw "Unsupported system: ${system}");
 

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,28 @@
                 llvm.libclang.python
                 llvm.lld
                 llvm.libllvm
-                llvm.clang
+
+                (symlinkJoin {
+                  name = "clang-complete";
+                  paths = llvm.clang-unwrapped.all;
+
+                  # Clang searches up from the directory where it sits to find its built-in
+                  # headers. The `symlinkJoin` creates a symlink to the clang binary, and that
+                  # symlink is what ends up in your PATH from this shell. However, that symlink's
+                  # destination, the clang binary file, still resides in its own nix store
+                  # entry (`llvm.clang-unwrapped`), isolated from the header files (found in
+                  # `llvm.clang-unwrapped.lib` under `lib/clang/18/include`). So when search up its
+                  # parent directories, no built-in headers are found.
+                  #
+                  # By copying over the clang binary over the symlinks in the realisation of the
+                  # `symlinkJoin`, we can fix this; now the search mechanism looks up the parent
+                  # directories of the `clang` binary (which is a copy created by below command),
+                  # until it finds the aforementioned `lib/clang/18/include` (where the `lib` is
+                  # actually a symlink to `llvm.clang-unwrapped.lib + "/lib"`).
+                  postBuild = ''
+                    cp --remove-destination -- ${llvm.clang-unwrapped}/bin/* $out/bin/
+                  '';
+                })
               ];
 
               # To avoid Nix adding compiler flags that are not available on a freestanding


### PR DESCRIPTION
1. remove a bunch of warnings from nix quirks
2. re-add nix examples to CI
3. ~~compiler faster by using the power of *multiprocessors*~~ nevermind
4. make nix not use dependencies from the ambient environment