### PR TITLE
Remove export override directives

### DIFF
--- a/examples/vmm/Makefile
+++ b/examples/vmm/Makefile
@@ -7,26 +7,27 @@
 ifeq ($(strip $(MICROKIT_SDK)),)
 $(error MICROKIT_SDK must be specified)
 endif
-export override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
+override MICROKIT_SDK := $(abspath ${MICROKIT_SDK})
 export EXAMPLE_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 LIONSOS ?= ../../
 export LIONSOS := $(abspath ${LIONSOS})
 export SDDF := ${LIONSOS}/dep/sddf
 export MICROKIT_CONFIG ?= debug
-export BUILD_DIR ?= $(abspath build)
+BUILD_DIR ?= build
+export BUILD_DIR := $(abspath ${BUILD_DIR})
 export MICROKIT_BOARD := odroidc4
 export VMM_IMAGE_DIR := ${EXAMPLE_DIR}/vmm
 export ORIGINAL_DTB := $(VMM_IMAGE_DIR)/meson-sm1-odroid-c4.dtb
 
 VARIANT ?= passthrough
 ifeq (${VARIANT},passthrough)
-export SYSTEM:=${EXAMPLE_DIR}/vmm.system
-export DT_OVERLAYS:= ${VMM_IMAGE_DIR}/overlay.dts
-VAR_MAKEFILE:= vmm-dev.mk
+export SYSTEM := ${EXAMPLE_DIR}/vmm.system
+export DT_OVERLAYS := ${VMM_IMAGE_DIR}/overlay.dts
+VAR_MAKEFILE := vmm-dev.mk
 else
-export SYSTEM:=${EXAMPLE_DIR}/vmm-virtio-console.system
-export DT_OVERLAYS:= ${VMM_IMAGE_DIR}/overlay-virtcon.dts
-VAR_MAKEFILE:= vmm-virtio-console.mk
+export SYSTEM := ${EXAMPLE_DIR}/vmm-virtio-console.system
+export DT_OVERLAYS := ${VMM_IMAGE_DIR}/overlay-virtcon.dts
+VAR_MAKEFILE := vmm-virtio-console.mk
 endif
 
 IMAGE_FILE := $(BUILD_DIR)/vmdev.img

--- a/examples/vmm/vmm-dev.mk
+++ b/examples/vmm/vmm-dev.mk
@@ -30,7 +30,7 @@ TOOLCHAIN := clang
 CC := clang
 LD := ld.lld
 TARGET := aarch64-none-elf
-CHECK_VARIANT:=.variant.$(shell md5sum ${SYSTEM})
+CHECK_VARIANT := .variant.$(shell md5sum ${SYSTEM})
 .variant.%:
 	-rm -f .variant.*
 	> $@
@@ -67,7 +67,7 @@ CFLAGS := \
 	-I$(LIBVMM)/include \
 	-MD
 
-VPATH:=${LIBVMM}:${VMM_IMAGE_DIR}
+VPATH := ${LIBVMM}:${VMM_IMAGE_DIR}
 
 LDFLAGS := -L$(BOARD_DIR)/lib
 LIBS := -lmicrokit -Tmicrokit.ld

--- a/examples/vmm/vmm-virtio-console.mk
+++ b/examples/vmm/vmm-virtio-console.mk
@@ -35,7 +35,7 @@ CC := clang
 LD := ld.lld
 TARGET := aarch64-none-elf
 
-CHECK_VARIANT:=.variant.$(shell md5sum ${SYSTEM})
+CHECK_VARIANT := .variant.$(shell md5sum ${SYSTEM})
 .variant.%:
 	-rm -f .variant.*
 	> $@
@@ -76,7 +76,7 @@ CFLAGS := \
 	-MD \
 	-DMAC_BASE_ADDRESS=$(MAC_BASE_ADDRESS)
 
-VPATH:=${LIBVMM_DIR}:${VMM_IMAGE_DIR}
+VPATH := ${LIBVMM_DIR}:${VMM_IMAGE_DIR}
 # we have only one client
 SERIAL_NUM_CLIENTS := -DSERIAL_NUM_CLIENTS=1
 


### PR DESCRIPTION
This PR is an extension of the sDDF PR here (https://github.com/au-ts/sddf/pull/423).

This PR removes all `export override` directives from our makefiles, as discussed here #337.

It was found that `export override` is not syntactically correct in older versions of GNU make, which happen to be the default for MacOS. Also, the variables which it was being applied to were mandatory environment or command line variables, therefore the `export` had no effect. 