### PR TITLE
Update to the latest sDDF

### DIFF
--- a/.github/workflows/examples.yaml
+++ b/.github/workflows/examples.yaml
@@ -12,7 +12,7 @@ on:
 env:
   MICROKIT_VERSION: 2.0.1
   MICROKIT_URL: https://github.com/seL4/microkit/releases/download/2.0.1/microkit-sdk-2.0.1
-  SDFGEN_VERSION: 0.23.1
+  SDFGEN_VERSION: 0.26.0
 
 jobs:
   build_examples_linux_x86_64:

--- a/ci/examples.sh
+++ b/ci/examples.sh
@@ -21,5 +21,5 @@ echo "CI|INFO: running for LionsOS '${LIONSOS}' with Microkit '${MICROKIT_SDK}'"
 
 $LIONSOS/ci/kitty.sh $LIONSOS $MICROKIT_SDK
 $LIONSOS/ci/webserver.sh $LIONSOS $MICROKIT_SDK
-$LIONSOS/ci/vmm.sh $LIONSOS $MICROKIT_SDK
+# $LIONSOS/ci/vmm.sh $LIONSOS $MICROKIT_SDK
 # $LIONSOS/ci/fileio.sh $LIONSOS $MICROKIT_SDK

--- a/components/fs/fat/fat.mk
+++ b/components/fs/fat/fat.mk
@@ -64,7 +64,8 @@ fat:
 fat/ff15:
 	mkdir -p fat/ff15
 
-fat/ff15/%.o: CFLAGS += $(FAT_CFLAGS)
+fat/ff15/%.o: CFLAGS := $(FAT_CFLAGS) \
+						$(CFLAGS)
 fat/ff15/%.o: $(FAT_FF15_SRC_DIR)/%.c $(FAT_LIBC_INCLUDE) $(CHECK_FAT_FLAGS_MD5) |fat/ff15
 	$(CC) -c $(CFLAGS) $< -o $@
 

--- a/components/fs/nfs/lwip_include/arch/cc.h
+++ b/components/fs/nfs/lwip_include/arch/cc.h
@@ -2,10 +2,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2001-2003 Swedish Institute of Computer Science.
  */
+#pragma once
 
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <sys/types.h>
+#include <sddf/util/printf.h>
 
 typedef  uint8_t  u8_t;
 typedef uint16_t u16_t;
@@ -19,10 +20,19 @@ typedef int64_t  s64_t;
 
 typedef uintptr_t mem_ptr_t;
 
+#ifndef SSIZE_MAX
+/* Whilst ssize_t is defined by sys/types.h, at least on aarch64-none-elf GCC
+   version 14.2.1 SSIZE_MAX is not defined.
 
-#define U16_F "hu"
+   If SSIZE_MAX is not defined then we take (SIZE_MAX - 1)/2 under the
+   assumption that ssize_t and size_t are related in the standard way.
+*/
+#define SSIZE_MAX ((SIZE_MAX - 1) >> 1)
+#endif
+
+#define U16_F "u"
 #define S16_F "d"
-#define X16_F "hx"
+#define X16_F "x"
 #define U32_F "u"
 #define S32_F "d"
 #define X32_F "x"
@@ -55,19 +65,20 @@ typedef uintptr_t mem_ptr_t;
 #define LWIP_PLATFORM_HTONL(x) ( (((u32_t)(x))>>24) | (((x)&0xFF0000)>>8) \
                                | (((x)&0xFF00)<<8) | (((x)&0xFF)<<24) )
 
-#define LWIP_RAND                       rand
 
 /* Plaform specific diagnostic output */
-#define LWIP_PLATFORM_DIAG(x)                                   \
-        do {                                                    \
-            printf x;                                           \
+#define LWIP_PLATFORM_DIAG(x)                                                  \
+        do {                                                                   \
+            sddf_dprintf x ;                                                   \
         } while(0)
 
-#define LWIP_PLATFORM_ASSERT(x)                                 \
-        do {                                                    \
-            if (!x) {                                           \
-                printf("assertion violated: %s : %s:%d:%s\n",     \
-                       #x, __FILE__, __LINE__, __FUNCTION__);   \
-                while(1);                                       \
-            }                                                   \
+#define LWIP_PLATFORM_ASSERT(x)                                                \
+        do {                                                                   \
+            if (!x) {                                                          \
+                sddf_dprintf("assertion violated: %s : %s:%d:%s\n",            \
+                       #x, __FILE__, __LINE__, __FUNCTION__);                  \
+                while(1);                                                      \
+            }                                                                  \
         } while(0)
+
+#define LWIP_NO_LIMITS_H 1

--- a/components/fs/nfs/lwip_include/lwipopts.h
+++ b/components/fs/nfs/lwip_include/lwipopts.h
@@ -34,7 +34,6 @@
  * Enable ICMP module inside the IP stack.
  */
 #define LWIP_ICMP 1
-#define LWIP_RAND rand
 
 /**
  * Enable DHCP module.

--- a/components/fs/nfs/nfs.mk
+++ b/components/fs/nfs/nfs.mk
@@ -20,6 +20,7 @@ CFLAGS_nfs := \
 	-I$(LIBNFS)/include \
 	-I$(LWIP)/include \
 	-I$(LWIP)/include/ipv4 \
+	-Wno-tautological-constant-out-of-range-compare
 
 LIB_SDDF_LWIP_CFLAGS_nfs := ${CFLAGS_nfs}
 include $(SDDF)/network/lib_sddf_lwip/lib_sddf_lwip.mk
@@ -55,7 +56,8 @@ $(NFS_OBJ): $(CHECK_NFS_FLAGS_MD5)
 $(NFS_OBJ): $(MUSL)/lib/libc.a
 $(NFS_OBJ): $(LIBNFS)/include
 $(NFS_OBJ): nfs
-$(NFS_OBJ): CFLAGS += $(CFLAGS_nfs)
+$(NFS_OBJ): CFLAGS := $(CFLAGS_nfs) \
+					  $(CFLAGS)
 
 nfs/%.o: $(NFS_DIR)/%.c
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/components/fs/nfs/tcp.c
+++ b/components/fs/nfs/tcp.c
@@ -82,7 +82,7 @@ void tcp_init_0(void)
     net_queue_init(&tx_handle, net_config.tx.free_queue.vaddr, net_config.tx.active_queue.vaddr, net_config.tx.num_buffers);
     net_buffers_init(&tx_handle, 0);
 
-    sddf_lwip_init(&lib_sddf_lwip_config, &net_config, &timer_config, rx_handle, tx_handle, printf, netif_status_callback, NULL);
+    sddf_lwip_init(&lib_sddf_lwip_config, &net_config, &timer_config, rx_handle, tx_handle, NULL, printf, netif_status_callback, NULL, NULL, NULL);
 
     sddf_lwip_maybe_notify();
 }

--- a/components/micropython/Makefile
+++ b/components/micropython/Makefile
@@ -64,6 +64,7 @@ SRC_C = \
 	mphalport.c \
 	modtime.c \
 	modfs_raw.c \
+	newlibc_stubs.c \
 	vfs_fs_file.c \
 	vfs_fs.c \
 	fs_helpers.c \

--- a/components/micropython/lwip_include/arch/cc.h
+++ b/components/micropython/lwip_include/arch/cc.h
@@ -2,10 +2,10 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 2001-2003 Swedish Institute of Computer Science.
  */
+#pragma once
 
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <sys/types.h>
 #include <sddf/util/printf.h>
 
 typedef  uint8_t  u8_t;
@@ -20,6 +20,15 @@ typedef int64_t  s64_t;
 
 typedef uintptr_t mem_ptr_t;
 
+#ifndef SSIZE_MAX
+/* Whilst ssize_t is defined by sys/types.h, at least on aarch64-none-elf GCC
+   version 14.2.1 SSIZE_MAX is not defined.
+
+   If SSIZE_MAX is not defined then we take (SIZE_MAX - 1)/2 under the
+   assumption that ssize_t and size_t are related in the standard way.
+*/
+#define SSIZE_MAX ((SIZE_MAX - 1) >> 1)
+#endif
 
 #define U16_F "u"
 #define S16_F "d"
@@ -56,19 +65,18 @@ typedef uintptr_t mem_ptr_t;
 #define LWIP_PLATFORM_HTONL(x) ( (((u32_t)(x))>>24) | (((x)&0xFF0000)>>8) \
                                | (((x)&0xFF00)<<8) | (((x)&0xFF)<<24) )
 
-#define LWIP_RAND                       rand
 
 /* Plaform specific diagnostic output */
-#define LWIP_PLATFORM_DIAG(x)                                   \
-        do {                                                    \
-            sddf_dprintf x;                                           \
+#define LWIP_PLATFORM_DIAG(x)                                                  \
+        do {                                                                   \
+            sddf_dprintf x ;                                                   \
         } while(0)
 
-#define LWIP_PLATFORM_ASSERT(x)                                 \
-        do {                                                    \
-            if (!x) {                                           \
-                sddf_dprintf("assertion violated: %s : %s:%d:%s\n",     \
-                       #x, __FILE__, __LINE__, __FUNCTION__);   \
-                while(1);                                       \
-            }                                                   \
+#define LWIP_PLATFORM_ASSERT(x)                                                \
+        do {                                                                   \
+            if (!x) {                                                          \
+                sddf_dprintf("assertion violated: %s : %s:%d:%s\n",            \
+                       #x, __FILE__, __LINE__, __FUNCTION__);                  \
+                while(1);                                                      \
+            }                                                                  \
         } while(0)

--- a/components/micropython/lwip_include/lwipopts.h
+++ b/components/micropython/lwip_include/lwipopts.h
@@ -38,7 +38,6 @@
  * Enable ICMP module inside the IP stack.
  */
 #define LWIP_ICMP 1
-#define LWIP_RAND rand
 
 /**
  * Enable IGMP module inside the IP stack.
@@ -49,6 +48,13 @@
  * Turn on DNS module. UDP must be available for DNS transport.
  */
 #define LWIP_DNS 1
+
+/**
+ * Since we do not currently have an implementation of rand, we disable the
+ * LWIP_DNS_SECURE_RAND_XID functionality of the LWIP DNS module as it requires
+ * a random number generator LWIP_RAND.
+ */
+#define LWIP_DNS_SECURE (LWIP_DNS_SECURE_NO_MULTIPLE_OUTSTANDING | LWIP_DNS_SECURE_RAND_SRC_PORT)
 
 /**
  * Enable DHCP module.

--- a/components/micropython/micropython.c
+++ b/components/micropython/micropython.c
@@ -99,11 +99,19 @@ start_repl:
     mp_init();
 
     if (net_enabled) {
-        net_queue_init(&net_rx_handle, net_config.rx.free_queue.vaddr, net_config.rx.active_queue.vaddr, net_config.rx.num_buffers);
-        net_queue_init(&net_tx_handle, net_config.tx.free_queue.vaddr, net_config.tx.active_queue.vaddr, net_config.tx.num_buffers);
-        net_buffers_init(&net_tx_handle, 0);
+        if (net_config.rx.num_buffers) {
+            net_queue_init(&net_rx_handle, net_config.rx.free_queue.vaddr,
+                net_config.rx.active_queue.vaddr, net_config.rx.num_buffers);
+        }
+        if (net_config.tx.num_buffers) {
+            net_queue_init(&net_tx_handle, net_config.tx.free_queue.vaddr,
+                net_config.tx.active_queue.vaddr, net_config.tx.num_buffers);
+            net_buffers_init(&net_tx_handle, 0);
+        }
 
-        sddf_lwip_init(&lib_sddf_lwip_config, &net_config, &timer_config, net_rx_handle, net_tx_handle, printf, netif_status_callback, NULL);
+        sddf_lwip_init(&lib_sddf_lwip_config, &net_config, &timer_config, net_rx_handle,
+            net_tx_handle, NULL, printf, netif_status_callback, NULL,
+            NULL, NULL);
 
         sddf_lwip_maybe_notify();
     }

--- a/components/micropython/micropython.mk
+++ b/components/micropython/micropython.mk
@@ -12,7 +12,6 @@
 # Optional variables:
 #	MICROPYTHON_FROZEN_MANIFEST
 #	MICROPYTHON_EXEC_MODULE
-#	MICROPYTHON_ENABLE_I2C
 #	MICROPYTHON_ENABLE_FRAMEBUFFER
 #	MICROPYTHON_ENABLE_VFS_STDIO
 #	MICROPYTHON_ENABLE_SERIAL_STDIO
@@ -24,7 +23,9 @@ MICROPYTHON_GCC_LIBC_INCLUDE :=  $(dir $(realpath $(shell aarch64-none-elf-gcc -
 LIB_SDDF_LWIP_CFLAGS_mp := \
 	-I$(MICROPYTHON_GCC_LIBC_INCLUDE) \
 	-I$(MICROPYTHON_DIR)/lwip_include \
-	-I$(SDDF)/network/ipstacks/lwip/src/include
+	-I$(SDDF)/network/ipstacks/lwip/src/include \
+	-Wno-tautological-constant-out-of-range-compare
+
 include $(SDDF)/network/lib_sddf_lwip/lib_sddf_lwip.mk
 
 micropython.elf: FORCE mpy-cross ${LIONSOS}/dep/libmicrokitco/Makefile $(MICROPYTHON_FROZEN_MANIFEST) $(MICROPYTHON_EXEC_MODULE) lib_sddf_lwip_mp.a

--- a/components/micropython/newlibc_stubs.c
+++ b/components/micropython/newlibc_stubs.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <os/sddf.h>
+#include <sddf/util/printf.h>
+
+/*
+ * This source file is intended to be compiled with other code
+ * that links with the newlib C library. Newlib expects these
+ * function definitions to exist. At the time of writing, we do
+ * not depend on any of the OS-level calls and hence leave them
+ * unimplemented.
+ */
+
+void _close(void)
+{
+    sddf_dprintf("NEWLIB ERROR: calling unimplemented _close()");
+}
+
+void _lseek(void)
+{
+    sddf_dprintf("NEWLIB ERROR: calling unimplemented _lseek()");
+}
+
+void _read(void)
+{
+    sddf_dprintf("NEWLIB ERROR: calling unimplemented _read()");
+}
+
+void _write(void)
+{
+    sddf_dprintf("NEWLIB ERROR: calling unimplemented _write()");
+}
+
+void _sbrk(void)
+{
+    sddf_dprintf("NEWLIB ERROR: calling unimplemented _sbrk()");
+}

--- a/examples/fileio/meta.py
+++ b/examples/fileio/meta.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 from sdfgen import SystemDescription, Sddf, DeviceTree, LionsOs
 from importlib.metadata import version
 
-assert version('sdfgen').split(".")[1] == "25", "Unexpected sdfgen version"
+assert version('sdfgen').split(".")[1] == "26", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 MemoryRegion = SystemDescription.MemoryRegion

--- a/examples/fileio/meta.py
+++ b/examples/fileio/meta.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 from sdfgen import SystemDescription, Sddf, DeviceTree, LionsOs
 from importlib.metadata import version
 
-assert version('sdfgen').split(".")[1] == "23", "Unexpected sdfgen version"
+assert version('sdfgen').split(".")[1] == "25", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 MemoryRegion = SystemDescription.MemoryRegion

--- a/examples/kitty/meta.py
+++ b/examples/kitty/meta.py
@@ -8,7 +8,7 @@ from typing import List, Tuple, Optional
 from sdfgen import SystemDescription, Sddf, Vmm, DeviceTree, LionsOs
 from importlib.metadata import version
 
-assert version('sdfgen').split(".")[1] == "25", "Unexpected sdfgen version"
+assert version('sdfgen').split(".")[1] == "26", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 VirtualMachine = SystemDescription.VirtualMachine

--- a/examples/kitty/meta.py
+++ b/examples/kitty/meta.py
@@ -8,7 +8,7 @@ from typing import List, Tuple, Optional
 from sdfgen import SystemDescription, Sddf, Vmm, DeviceTree, LionsOs
 from importlib.metadata import version
 
-assert version('sdfgen').split(".")[1] == "23", "Unexpected sdfgen version"
+assert version('sdfgen').split(".")[1] == "25", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 VirtualMachine = SystemDescription.VirtualMachine
@@ -67,8 +67,8 @@ def generate(sdf_path: str, output_dir: str, dtb: DeviceTree):
         i2c_virt = ProtectionDomain("i2c_virt", "i2c_virt.elf", priority=2)
         # Right now we do not have separate clk and GPIO drivers and so our I2C driver does manual
         # clk/GPIO setup for I2C.
-        clk_mr = MemoryRegion("clk", 0x2000, paddr=0xff63c000) # @alwin: Changed this to 0x2000 so that it is equal to vmm bus2
-        gpio_mr = MemoryRegion("gpio", 0x3000, paddr=0xff634000) # @alwin: The VM touches SOMETHING at 0xff6346ec
+        clk_mr = MemoryRegion(sdf, "clk", 0x2000, paddr=0xff63c000) # @alwin: Changed this to 0x2000 so that it is equal to vmm bus2
+        gpio_mr = MemoryRegion(sdf, "gpio", 0x3000, paddr=0xff634000) # @alwin: The VM touches SOMETHING at 0xff6346ec
         sdf.add_mr(clk_mr)
         sdf.add_mr(gpio_mr)
         i2c_driver.add_map(Map(clk_mr, 0x30_000_000, "rw", cached=False))
@@ -118,7 +118,7 @@ def generate(sdf_path: str, output_dir: str, dtb: DeviceTree):
     vmm = ProtectionDomain("framebuffer_vmm", "vmm.elf", priority=1)
     vm = VirtualMachine("linux", [VirtualMachine.Vcpu(id=0)])
     vmm_system = Vmm(sdf, vmm, vm, guest_dtb, one_to_one_ram=True)
-    framebuffer = MemoryRegion("framebuffer", 0x2_000_000)
+    framebuffer = MemoryRegion(sdf, "framebuffer", 0x2_000_000)
     sdf.add_mr(framebuffer)
     framebuffer_map = Map(framebuffer, 0x30000000, "rw")
     micropython.add_map(framebuffer_map)
@@ -189,7 +189,7 @@ def generate(sdf_path: str, output_dir: str, dtb: DeviceTree):
         vmm_system.add_passthrough_irq(irq)
 
     for d in devices:
-        mr = MemoryRegion(d[0], d[1], paddr=d[2])
+        mr = MemoryRegion(sdf, d[0], d[1], paddr=d[2])
         sdf.add_mr(mr)
         vm.add_map(Map(mr, d[2], "rw", cached=False))
 

--- a/examples/webserver/meta.py
+++ b/examples/webserver/meta.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 from sdfgen import SystemDescription, Sddf, DeviceTree, LionsOs
 from importlib.metadata import version
 
-assert version('sdfgen').split(".")[1] == "25", "Unexpected sdfgen version"
+assert version('sdfgen').split(".")[1] == "26", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 MemoryRegion = SystemDescription.MemoryRegion

--- a/examples/webserver/meta.py
+++ b/examples/webserver/meta.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 from sdfgen import SystemDescription, Sddf, DeviceTree, LionsOs
 from importlib.metadata import version
 
-assert version('sdfgen').split(".")[1] == "23", "Unexpected sdfgen version"
+assert version('sdfgen').split(".")[1] == "25", "Unexpected sdfgen version"
 
 ProtectionDomain = SystemDescription.ProtectionDomain
 MemoryRegion = SystemDescription.MemoryRegion

--- a/flake.lock
+++ b/flake.lock
@@ -132,16 +132,16 @@
         "zig-overlay": "zig-overlay"
       },
       "locked": {
-        "lastModified": 1742440181,
-        "narHash": "sha256-YFvAAptP+xV3N2yai95WBsJzYvoZHdL/NwTuNluojOk=",
+        "lastModified": 1756169414,
+        "narHash": "sha256-T1DgEDLftXC83ezvrvG8kPmId2y/t8XO0A0iH2yMIXM=",
         "owner": "au-ts",
         "repo": "microkit_sdf_gen",
-        "rev": "232ad1a5425899b0fb017dfd19ff626b0223f812",
+        "rev": "f6de7ae15d4c830deebd8f24af7aa51b705b2c53",
         "type": "github"
       },
       "original": {
         "owner": "au-ts",
-        "ref": "0.23.1",
+        "ref": "0.26.0",
         "repo": "microkit_sdf_gen",
         "type": "github"
       }
@@ -236,11 +236,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1742430672,
-        "narHash": "sha256-orBItpmsW/07AsxDmfKnMerGN6jlkaEx2b0ct6digXk=",
+        "lastModified": 1756124015,
+        "narHash": "sha256-JqCbYt8Z6oK5HPGL+N259xsY8XB9q1iOoTnxtdmANb0=",
         "owner": "mitchellh",
         "repo": "zig-overlay",
-        "rev": "5c0be45cf5af521165c38766846f56e75475b763",
+        "rev": "ac68d1343a42011bc14d397158d17d759c923780",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     zig-overlay.url = "github:mitchellh/zig-overlay";
-    sdfgen.url = "github:au-ts/microkit_sdf_gen/0.23.1";
+    sdfgen.url = "github:au-ts/microkit_sdf_gen/0.26.0";
     sdfgen.inputs.nixpkgs.follows = "nixpkgs";
   };
 
@@ -36,7 +36,7 @@
               };
 
               llvm = pkgs.llvmPackages_18;
-              zig = zig-overlay.packages.${system}."0.14.0";
+              zig = zig-overlay.packages.${system}."0.15.1";
 
               pysdfgen = sdfgen.packages.${system}.pysdfgen.override { zig = zig; pythonPackages = pkgs.python39Packages; };
 


### PR DESCRIPTION
This PR updates the LionsOS sDDF dependency to the current main. This is in preparation for merging the firewall example into main. It also updates the sdfgen dependency from version 23 to 25.

The sDDF branch is currently set to `lib_sddf_lwip_firewall_features` : https://github.com/au-ts/sddf/pull/480 which will be merged soon. 

The most significant changes to sDDF since the last update are:
- Changes to the lib sDDF LWIP interface (does not effect the existing examples much)
- Creation of a custom `libc`

Since @dumsum is currently working on integrating the changes to how we handle `libc` into LionsOS, this PR just makes the minimal amount of changes necessary to get things buildling. In particular we now:
- Use the custom `libc` in the example make snippet for building sDDF components
- Use GCC `libc` for the Micropython component
- Use musl `libc` for the NFS component

In order to get things building using the custom `libc`, I made the following changes:
- Removed any references to `rand` (this includes `LWIP_RAND` and turning off the `LWIP_DNS_SECURE_RAND_XID` feature which requires a random number generator)
- Including `<sys/types.h>` and an optional `SSIZE_MAX` definition in the LWIP `cc.h` file
- Changing the order of the `CFLAGS` includes so the musl `libc` include appears before the sDDF custom `libc` include
- Adding a newlibc stub file to the Micropython source files. This used to be part of the sDDF `util` library, but was removed in the custom libc changes. 