### PR TITLE
Add firewall example to LionsOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ docs/book/
 *~
 \#*#
 .#*
+__pycache__
+config_structs.py

--- a/components/micropython/Makefile
+++ b/components/micropython/Makefile
@@ -63,6 +63,7 @@ SRC_C = \
 	micropython.c \
 	mphalport.c \
 	modtime.c \
+	mpfirewallport.c \
 	modfs_raw.c \
 	newlibc_stubs.c \
 	vfs_fs_file.c \
@@ -89,10 +90,11 @@ SRC_C = \
 	shared/libc/printf.c \
 	shared/libc/__errno.c \
 	shared/timeutils/timeutils.c \
-	shared/netutils/netutils.c
+	shared/netutils/netutils.c \
+	$(USER_C_MODULES)
 
 # Define source files containung qstrs.
-SRC_QSTR += shared/readline/readline.c shared/runtime/pyexec.c vfs_fs_file.c vfs_fs.c modfs_raw.c
+SRC_QSTR += shared/readline/readline.c shared/runtime/pyexec.c vfs_fs_file.c vfs_fs.c modfs_raw.c $(USER_C_MODULES)
 
 # Frozen module to execute; otherwise run REPL
 ifdef EXEC_MODULE
@@ -117,6 +119,8 @@ ifdef ENABLE_SERIAL_STDIO
 SRC_C += shared/runtime/sys_stdio_mphal.c
 CFLAGS += -DENABLE_SERIAL_STDIO
 endif
+
+# $(error $(CFLAGS))
 
 # Define the required object files.
 OBJ = $(PY_CORE_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))

--- a/components/micropython/micropython.mk
+++ b/components/micropython/micropython.mk
@@ -15,8 +15,13 @@
 #	MICROPYTHON_ENABLE_FRAMEBUFFER
 #	MICROPYTHON_ENABLE_VFS_STDIO
 #	MICROPYTHON_ENABLE_SERIAL_STDIO
+#   MICROPYTHON_USER_C_MODULES (assumed to be located in MICROPYTHON_DIR)
 
 MICROPYTHON_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+
+ifneq ($(strip $(MICROPYTHON_USER_C_MODULES)),)
+	MICROPYTHON_USER_C_MODULES_PATH := $(MICROPYTHON_DIR)/$(MICROPYTHON_USER_C_MODULES)
+endif
 
 MICROPYTHON_GCC_LIBC_INCLUDE :=  $(dir $(realpath $(shell aarch64-none-elf-gcc --print-file-name libc.a)))/../include
 
@@ -28,7 +33,7 @@ LIB_SDDF_LWIP_CFLAGS_mp := \
 
 include $(SDDF)/network/lib_sddf_lwip/lib_sddf_lwip.mk
 
-micropython.elf: FORCE mpy-cross ${LIONSOS}/dep/libmicrokitco/Makefile $(MICROPYTHON_FROZEN_MANIFEST) $(MICROPYTHON_EXEC_MODULE) lib_sddf_lwip_mp.a
+micropython.elf: FORCE mpy-cross ${LIONSOS}/dep/libmicrokitco/Makefile $(MICROPYTHON_FROZEN_MANIFEST) $(MICROPYTHON_EXEC_MODULE) $(MICROPYTHON_USER_C_MODULES_PATH) lib_sddf_lwip_mp.a
 	$(MAKE) -C $(MICROPYTHON_DIR) \
 		-j$(nproc) \
 		MICROKIT_SDK=$(MICROKIT_SDK) \
@@ -42,7 +47,8 @@ micropython.elf: FORCE mpy-cross ${LIONSOS}/dep/libmicrokitco/Makefile $(MICROPY
 		EXEC_MODULE=$(MICROPYTHON_EXEC_MODULE) \
 		ENABLE_FRAMEBUFFER=$(MICROPYTHON_ENABLE_FRAMEBUFFER) \
 		ENABLE_VFS_STDIO=$(MICROPYTHON_ENABLE_VFS_STDIO) \
-		ENABLE_SERIAL_STDIO=$(MICROPYTHON_ENABLE_SERIAL_STDIO)
+		ENABLE_SERIAL_STDIO=$(MICROPYTHON_ENABLE_SERIAL_STDIO) \
+		USER_C_MODULES=$(MICROPYTHON_USER_C_MODULES)
 
 mpy-cross: FORCE $(LIONSOS)/dep/micropython/mpy-cross
 	make -C $(LIONSOS)/dep/micropython/mpy-cross BUILD=$(abspath ./mpy_cross)

--- a/components/micropython/modfirewall.c
+++ b/components/micropython/modfirewall.c
@@ -1,0 +1,547 @@
+/*
+ * Copyright 2025, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdint.h>
+#include <os/sddf.h>
+#include <py/runtime.h>
+#include <sddf/network/util.h>
+#include <sddf/util/printf.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/filter.h>
+#include <lions/firewall/protocols.h>
+#include <lions/firewall/routing.h>
+
+#include "mpfirewallport.h"
+
+/* Firewall internal errors */
+typedef enum {
+    OS_ERR_OKAY = 0,          /* No error */
+    OS_ERR_INVALID_INTERFACE, /* Invalid interface ID */
+    OS_ERR_INVALID_PROTOCOL,  /* Invalid protocol number */
+    OS_ERR_INVALID_ROUTE_ID,  /* Invalid route ID */
+    OS_ERR_INVALID_RULE_ID,   /* Invalid rule ID */
+    OS_ERR_INVALID_ROUTE_ARGS,/* Invalid arguments to add route */
+    OS_ERR_DUPLICATE,         /* Duplicate route or rule */
+    OS_ERR_CLASH,             /* Clashing route or rule */
+    OS_ERR_INVALID_ARGUMENTS, /* Invalid arguments supplied */
+    OS_ERR_INVALID_ROUTE_NUM, /* Invalid route number supplied to route_get_nth */
+    OS_ERR_INVALID_RULE_NUM,  /* Invalid route number supplied to rule_get_nth */
+    OS_ERR_OUT_OF_MEMORY,     /* Data structures full */
+    OS_ERR_INTERNAL_ERROR     /* Unknown internal error */
+} fw_os_err_t;
+
+static const char *fw_os_err_str[] = {
+    "Ok.",
+    "Invalid interface ID supplied.",
+    "No matching filter for supplied protocol number.",
+    "No route matching supplied route ID.",
+    "No rule matching supplied rule ID.",
+    "Invalid arguments supplied to add route.",
+    "Route or rule supplied already exists.",
+    "Route or rule supplied clashes with an existing route or rule.",
+    "Too many or too few arguments supplied.",
+    "Route number supplied is greater than the number of routes.",
+    "Rule number supplied is greater than the number of rules.",
+    "Internal data structures are already at capacity.",
+    "Unknown internal error."
+};
+
+/* Convert a routing error to OS error */
+static fw_os_err_t fw_routing_err_to_os_err(fw_routing_err_t routing_err)
+{
+    switch (routing_err) {
+        case ROUTING_ERR_OKAY:
+            return OS_ERR_OKAY;
+        case ROUTING_ERR_FULL:
+            return OS_ERR_OUT_OF_MEMORY;
+        case ROUTING_ERR_DUPLICATE:
+            return OS_ERR_DUPLICATE;
+        case ROUTING_ERR_CLASH:
+            return OS_ERR_CLASH;
+        case ROUTING_ERR_INVALID_ID:
+            return OS_ERR_INVALID_ROUTE_ID;
+        case ROUTING_ERR_INVALID_ROUTE:
+            return OS_ERR_INVALID_ROUTE_ARGS;
+        default:
+            return OS_ERR_INTERNAL_ERROR;
+    }
+}
+
+/* Convert a filter error to OS error */
+static fw_os_err_t filter_err_to_os_err(fw_filter_err_t filter_err)
+{
+    switch (filter_err) {
+        case FILTER_ERR_OKAY:
+            return OS_ERR_OKAY;
+        case FILTER_ERR_FULL:
+            return OS_ERR_OUT_OF_MEMORY;
+        case FILTER_ERR_DUPLICATE:
+            return OS_ERR_DUPLICATE;
+        case FILTER_ERR_CLASH:
+            return OS_ERR_CLASH;
+        case FILTER_ERR_INVALID_RULE_ID:
+            return OS_ERR_INVALID_RULE_ID;
+        default:
+            return OS_ERR_INTERNAL_ERROR;
+    }
+}
+
+/* Get MAC address for network interface */
+static mp_obj_t interface_get_mac(mp_obj_t interface_idx_in) {
+    uint8_t interface_idx = mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    mp_obj_t tuple[ETH_HWADDR_LEN];
+    for (uint8_t i = 0; i < ETH_HWADDR_LEN; i++) {
+        tuple[i] = mp_obj_new_int_from_uint(fw_config.interfaces[interface_idx].mac_addr[i]);
+    }
+
+    return mp_obj_new_tuple(ETH_HWADDR_LEN, tuple);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_1(interface_get_mac_obj, interface_get_mac);
+
+/* Get IP address for network interface */
+static mp_obj_t interface_get_ip(mp_obj_t interface_idx_in) {
+    uint8_t interface_idx = mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    return mp_obj_new_int_from_uint(fw_config.interfaces[interface_idx].ip);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_1(interface_get_ip_obj, interface_get_ip);
+
+/* Add a route to the routing table for a network interface */
+static mp_obj_t route_add(mp_uint_t n_args, const mp_obj_t *args) {
+    if (n_args != 4) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_ARGUMENTS]);
+        mp_raise_OSError(OS_ERR_INVALID_ARGUMENTS);
+        return mp_const_none;
+    }
+
+    uint8_t interface_idx = mp_obj_get_int(args[0]);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    uint32_t ip = mp_obj_get_int(args[1]);
+    uint8_t subnet = mp_obj_get_int(args[2]);
+    uint32_t next_hop = mp_obj_get_int(args[3]);
+
+    seL4_SetMR(ROUTER_ARG_IP, ip);
+    seL4_SetMR(ROUTER_ARG_SUBNET, subnet);
+    seL4_SetMR(ROUTER_ARG_NEXT_HOP, next_hop);
+
+    microkit_msginfo msginfo =
+        microkit_ppcall(fw_config.interfaces[interface_idx].router.routing_ch,
+                        microkit_msginfo_new(FW_ADD_ROUTE, 4));
+    fw_os_err_t os_err = fw_routing_err_to_os_err(seL4_GetMR(ROUTER_RET_ERR));
+    if (os_err != OS_ERR_OKAY) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[os_err]);
+        mp_raise_OSError(os_err);
+        return mp_obj_new_int_from_uint(os_err);
+    }
+
+    return mp_obj_new_int_from_uint(os_err);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_VAR(route_add_obj, 4, route_add);
+
+/* Delete a route from the interface routing table */
+static mp_obj_t route_delete(mp_obj_t interface_idx_in, mp_obj_t route_id_in) {
+    uint8_t interface_idx =   mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    uint16_t route_id = mp_obj_get_int(route_id_in);
+
+    seL4_SetMR(ROUTER_ARG_ROUTE_ID, route_id);
+    microkit_msginfo msginfo =
+        microkit_ppcall(fw_config.interfaces[interface_idx].router.routing_ch,
+                        microkit_msginfo_new(FW_DEL_ROUTE, 1));
+    fw_os_err_t os_err = fw_routing_err_to_os_err(seL4_GetMR(ROUTER_RET_ERR));
+    if (os_err != OS_ERR_OKAY) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[os_err]);
+        mp_raise_OSError(os_err);
+        return mp_obj_new_int_from_uint(os_err);
+    }
+
+    return mp_obj_new_int_from_uint(route_id);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_2(route_delete_obj, route_delete);
+
+/* Count the number of routes in an interface routing table */
+static mp_obj_t route_count(mp_obj_t interface_idx_in) {
+    uint8_t interface_idx =   mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    return mp_obj_new_int_from_uint(webserver_state[interface_idx].routing_table->size);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_1(route_count_obj, route_count);
+
+/* Return nth route in interface routing table */
+static mp_obj_t route_get_nth(mp_obj_t interface_idx_in,
+                              mp_obj_t route_idx_in) {
+    uint8_t interface_idx =   mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    uint16_t route_idx = mp_obj_get_int(route_idx_in);
+    if (route_idx >= webserver_state[interface_idx].routing_table->size) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_ROUTE_NUM]);
+        mp_raise_OSError(OS_ERR_INVALID_ROUTE_NUM);
+        return mp_const_none;
+    }
+
+    fw_routing_entry_t *entry =
+            (fw_routing_entry_t
+                *)(webserver_state[interface_idx].routing_table->entries + route_idx);
+     
+    mp_obj_t tuple[4];
+    tuple[0] = mp_obj_new_int_from_uint(route_idx);
+    tuple[1] = mp_obj_new_int_from_uint(entry->ip);
+    tuple[2] = mp_obj_new_int_from_uint(entry->subnet);
+    tuple[3] = mp_obj_new_int_from_uint(entry->next_hop);
+    return mp_obj_new_tuple(4, tuple);
+
+    sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INTERNAL_ERROR]);
+    mp_raise_OSError(OS_ERR_INTERNAL_ERROR);
+    return mp_const_none;
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_2(route_get_nth_obj, route_get_nth);
+
+/* Add a rule to a filter on an interface */
+static mp_obj_t rule_add(mp_uint_t n_args, const mp_obj_t *args) {
+    if (n_args != 11) {
+        mp_raise_OSError(OS_ERR_INVALID_ARGUMENTS);
+        return mp_const_none;
+    }
+
+    uint8_t interface_idx = mp_obj_get_int(args[0]);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    uint16_t protocol = mp_obj_get_int(args[1]);
+    uint32_t src_ip = mp_obj_get_int(args[2]);
+    uint16_t src_port = mp_obj_get_int(args[3]);
+    bool src_port_any = mp_obj_get_int(args[4]);
+    uint8_t src_subnet = mp_obj_get_int(args[5]);
+    uint32_t dst_ip = mp_obj_get_int(args[6]);
+    uint16_t dst_port = mp_obj_get_int(args[7]);
+    bool dst_port_any = mp_obj_get_int(args[8]);
+    uint8_t dst_subnet = mp_obj_get_int(args[9]);
+    uint8_t action = mp_obj_get_int(args[10]);
+
+    uint8_t protocol_match = fw_config.interfaces[interface_idx].num_filters;
+    for (uint8_t i = 0; i < fw_config.interfaces[interface_idx].num_filters; i++) {
+        if (fw_config.interfaces[interface_idx].filters[i].protocol == protocol) {
+            protocol_match = i;
+            break;
+        }
+    }
+
+    if (protocol_match == fw_config.interfaces[interface_idx].num_filters) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INVALID_PROTOCOL]);
+        mp_raise_OSError(OS_ERR_INVALID_PROTOCOL);
+        return mp_const_none;
+    }
+
+    seL4_SetMR(FILTER_ARG_ACTION, action);
+    seL4_SetMR(FILTER_ARG_SRC_IP, src_ip);
+    seL4_SetMR(FILTER_ARG_SRC_PORT, src_port);
+    seL4_SetMR(FILTER_ARG_SRC_ANY_PORT, src_port_any);
+    seL4_SetMR(FILTER_ARG_SRC_SUBNET, src_subnet);
+    seL4_SetMR(FILTER_ARG_DST_IP, dst_ip);
+    seL4_SetMR(FILTER_ARG_DST_PORT, dst_port);
+    seL4_SetMR(FILTER_ARG_DST_ANY_PORT, dst_port_any);
+    seL4_SetMR(FILTER_ARG_DST_SUBNET, dst_subnet);
+
+    microkit_msginfo msginfo =
+        microkit_ppcall(fw_config.interfaces[interface_idx].filters[protocol_match].ch,
+                        microkit_msginfo_new(FW_ADD_RULE, 10));
+    fw_os_err_t os_err = filter_err_to_os_err(seL4_GetMR(FILTER_RET_ERR));
+    if (os_err != OS_ERR_OKAY) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[os_err]);
+        mp_raise_OSError(os_err);
+        return mp_obj_new_int_from_uint(os_err);
+    }
+
+    uint16_t rule_id = seL4_GetMR(FILTER_RET_RULE_ID);
+    webserver_state[interface_idx].num_rules[protocol_match] += 1;
+    return mp_obj_new_int_from_uint(rule_id);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_VAR(rule_add_obj, 9, rule_add);
+
+/* Delete a filter on an interface */
+static mp_obj_t rule_delete(mp_obj_t interface_idx_in, mp_obj_t rule_id_in,
+                            mp_obj_t protocol_in) {
+    uint8_t interface_idx = mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    uint16_t rule_id = mp_obj_get_int(rule_id_in);
+    uint16_t protocol = mp_obj_get_int(protocol_in);
+    uint8_t protocol_match = fw_config.interfaces[interface_idx].num_filters;
+    for (uint8_t i = 0; i < fw_config.interfaces[interface_idx].num_filters; i++) {
+        if (fw_config.interfaces[interface_idx].filters[i].protocol == protocol) {
+            protocol_match = i;
+            break;
+        }
+    }
+
+    if (protocol_match == fw_config.interfaces[interface_idx].num_filters) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INVALID_PROTOCOL]);
+        mp_raise_OSError(OS_ERR_INVALID_PROTOCOL);
+        return mp_const_none;
+    }
+
+    seL4_SetMR(FILTER_ARG_RULE_ID, rule_id);
+    microkit_msginfo msginfo =
+        microkit_ppcall(fw_config.interfaces[interface_idx].filters[protocol_match].ch,
+                        microkit_msginfo_new(FW_DEL_RULE, 2));
+    fw_os_err_t os_err = filter_err_to_os_err(seL4_GetMR(FILTER_RET_ERR));
+    if (os_err != OS_ERR_OKAY) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[os_err]);
+        mp_raise_OSError(os_err);
+        return mp_obj_new_int_from_uint(os_err);
+    }
+
+    webserver_state[interface_idx].num_rules[protocol_match] -= 1;
+    return mp_obj_new_int_from_uint(rule_id);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_3(rule_delete_obj, rule_delete);
+
+/* Get number of filter rules for a filter */
+static mp_obj_t rule_count(mp_obj_t interface_idx_in, mp_obj_t protocol_in) {
+    uint8_t interface_idx = mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    uint16_t protocol = mp_obj_get_int(protocol_in);
+    for (uint8_t i = 0; i < fw_config.interfaces[interface_idx].num_filters; i++) {
+        if (fw_config.interfaces[interface_idx].filters[i].protocol == protocol) {
+            return mp_obj_new_int_from_uint(webserver_state[interface_idx].num_rules[i]);
+        }
+    }
+
+    sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INVALID_PROTOCOL]);
+    mp_raise_OSError(OS_ERR_INVALID_PROTOCOL);
+    return mp_const_none;
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_2(rule_count_obj, rule_count);
+
+/* Set interface filter default action */
+static mp_obj_t filter_set_default_action(mp_obj_t interface_idx_in,
+                                          mp_obj_t protocol_in,
+                                          mp_obj_t action_in) {
+    uint8_t interface_idx = mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    uint16_t protocol = mp_obj_get_int(protocol_in);
+    uint8_t action = mp_obj_get_int(action_in);
+    uint8_t protocol_match = fw_config.interfaces[interface_idx].num_filters;
+    for (uint8_t i = 0; i < fw_config.interfaces[interface_idx].num_filters; i++) {
+        if (fw_config.interfaces[interface_idx].filters[i].protocol == protocol) {
+            protocol_match = i;
+            break;
+        }
+    }
+
+    if (protocol_match == fw_config.interfaces[interface_idx].num_filters) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INVALID_PROTOCOL]);
+        mp_raise_OSError(OS_ERR_INVALID_PROTOCOL);
+        return mp_const_none;
+    }
+
+    seL4_SetMR(FILTER_ARG_ACTION, action);
+    microkit_msginfo msginfo =
+        microkit_ppcall(fw_config.interfaces[interface_idx].filters[protocol_match].ch,
+                        microkit_msginfo_new(FW_SET_DEFAULT_ACTION, 1));
+    fw_os_err_t os_err = filter_err_to_os_err(seL4_GetMR(FILTER_RET_ERR));
+    if (os_err != OS_ERR_OKAY) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[os_err]);
+        mp_raise_OSError(os_err);
+        return mp_obj_new_int_from_uint(os_err);
+    }
+
+    webserver_state[interface_idx].filter_states[protocol_match].default_action = action;
+    return mp_obj_new_int_from_uint(os_err);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_3(filter_set_default_action_obj,
+                                 filter_set_default_action);
+
+/* Get interface filter default action */
+static mp_obj_t filter_get_default_action(mp_obj_t interface_idx_in,
+                                          mp_obj_t protocol_in) {
+    uint8_t interface_idx = mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    uint16_t protocol = mp_obj_get_int(protocol_in);
+    for (uint8_t i = 0; i < fw_config.interfaces[interface_idx].num_filters; i++) {
+        if (fw_config.interfaces[interface_idx].filters[i].protocol == protocol) {
+            return mp_obj_new_int_from_uint(
+                webserver_state[interface_idx].filter_states[i].default_action);
+        }
+    }
+
+    sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INVALID_PROTOCOL]);
+    mp_raise_OSError(OS_ERR_INVALID_PROTOCOL);
+    return mp_const_none;
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_2(filter_get_default_action_obj,
+                                 filter_get_default_action);
+
+/* Get the nth interface filter rule */
+static mp_obj_t rule_get_nth(mp_obj_t interface_idx_in, mp_obj_t protocol_in,
+                             mp_obj_t rule_idx_in) {
+    uint8_t interface_idx = mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    uint16_t protocol = mp_obj_get_int(protocol_in);
+    uint16_t rule_idx = mp_obj_get_int(rule_idx_in);
+    uint8_t protocol_match = fw_config.interfaces[interface_idx].num_filters;
+    for (uint8_t i = 0; i < fw_config.interfaces[interface_idx].num_filters; i++) {
+        if (fw_config.interfaces[interface_idx].filters[i].protocol == protocol) {
+            protocol_match = i;
+            break;
+        }
+    }
+
+    if (protocol_match == fw_config.interfaces[interface_idx].num_filters) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INVALID_PROTOCOL]);
+        mp_raise_OSError(OS_ERR_INVALID_PROTOCOL);
+        return mp_const_none;
+    }
+
+    if (rule_idx >= webserver_state[interface_idx].num_rules[protocol_match] ||
+        rule_idx >= fw_config.interfaces[interface_idx].filters[protocol_match].rules_capacity) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INVALID_RULE_NUM]);
+        mp_raise_OSError(OS_ERR_INVALID_RULE_NUM);
+        return mp_const_none;
+    }
+
+    uint16_t valid_rules = 0;
+    for (uint16_t i = 0; i < webserver_state[interface_idx].filter_states[protocol_match].rules_capacity; i++) {
+            fw_rule_t *rule = (fw_rule_t *)(webserver_state[interface_idx].filter_states[protocol_match].rules + i);
+            if (!rule->valid) {
+                continue;
+            }
+
+            if (valid_rules == rule_idx) {
+                mp_obj_t tuple[10];
+                tuple[0] = mp_obj_new_int_from_uint(i);
+                tuple[1] = mp_obj_new_int_from_uint(rule->src_ip);
+                tuple[2] = mp_obj_new_int_from_uint(rule->src_port);
+                tuple[3] = mp_obj_new_int_from_uint(rule->src_port_any);
+                tuple[4] = mp_obj_new_int_from_uint(rule->dst_ip);
+                tuple[5] = mp_obj_new_int_from_uint(rule->dst_port);
+                tuple[6] = mp_obj_new_int_from_uint(rule->dst_port_any);
+                tuple[7] = mp_obj_new_int_from_uint(rule->src_subnet);
+                tuple[8] = mp_obj_new_int_from_uint(rule->dst_subnet);
+                tuple[9] = mp_obj_new_int_from_uint(rule->action);
+                return mp_obj_new_tuple(10, tuple);
+            }
+
+        valid_rules++;
+    }
+
+    sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INTERNAL_ERROR]);
+    mp_raise_OSError(OS_ERR_INTERNAL_ERROR);
+    return mp_const_none;
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_3(rule_get_nth_obj, rule_get_nth);
+
+static const mp_rom_map_elem_t lions_firewall_module_globals_table[] = {
+    {MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_lions_firewall)},
+    {MP_ROM_QSTR(MP_QSTR_interface_mac_get),
+     MP_ROM_PTR(&interface_get_mac_obj)},
+    {MP_ROM_QSTR(MP_QSTR_interface_ip_get), MP_ROM_PTR(&interface_get_ip_obj)},
+    {MP_ROM_QSTR(MP_QSTR_route_add), MP_ROM_PTR(&route_add_obj)},
+    {MP_ROM_QSTR(MP_QSTR_route_delete), MP_ROM_PTR(&route_delete_obj)},
+    {MP_ROM_QSTR(MP_QSTR_route_count), MP_ROM_PTR(&route_count_obj)},
+    {MP_ROM_QSTR(MP_QSTR_route_get_nth), MP_ROM_PTR(&route_get_nth_obj)},
+    {MP_ROM_QSTR(MP_QSTR_rule_add), MP_ROM_PTR(&rule_add_obj)},
+    {MP_ROM_QSTR(MP_QSTR_rule_delete), MP_ROM_PTR(&rule_delete_obj)},
+    {MP_ROM_QSTR(MP_QSTR_rule_count), MP_ROM_PTR(&rule_count_obj)},
+    {MP_ROM_QSTR(MP_QSTR_rule_get_nth), MP_ROM_PTR(&rule_get_nth_obj)},
+    {MP_ROM_QSTR(MP_QSTR_filter_get_default_action),
+     MP_ROM_PTR(&filter_get_default_action_obj)},
+    {MP_ROM_QSTR(MP_QSTR_filter_set_default_action),
+     MP_ROM_PTR(&filter_set_default_action_obj)},
+};
+
+static MP_DEFINE_CONST_DICT(lions_firewall_module_globals,
+                            lions_firewall_module_globals_table);
+
+const mp_obj_module_t lions_firewall_module = {
+    .base = {&mp_type_module},
+    .globals = (mp_obj_dict_t *)&lions_firewall_module_globals,
+};
+
+MP_REGISTER_MODULE(MP_QSTR_lions_firewall, lions_firewall_module);

--- a/components/micropython/mpconfigport.h
+++ b/components/micropython/mpconfigport.h
@@ -94,6 +94,9 @@ typedef long mp_off_t;
 #elif defined(CONFIG_PLAT_IMX8MM_EVK)
 #define MICROPY_HW_BOARD_NAME "i.MX 8M Mini"
 #define MICROPY_HW_MCU_NAME   "Cortex A53"
+#elif defined(CONFIG_PLAT_IMX8MP_EVK)
+#define MICROPY_HW_BOARD_NAME "i.MX 8MP"
+#define MICROPY_HW_MCU_NAME   "Cortex A53"
 #elif defined(CONFIG_PLAT_MAAXBOARD)
 #define MICROPY_HW_BOARD_NAME "MaaXBoard"
 #define MICROPY_HW_MCU_NAME   "Cortex A53"

--- a/components/micropython/mpfirewallport.c
+++ b/components/micropython/mpfirewallport.c
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <microkit.h>
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <string.h>
+#include <sddf/network/lib_sddf_lwip.h>
+#include <sddf/network/util.h>
+#include <lions/firewall/arp.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/queue.h>
+#include <lwip/ip.h>
+#include <lwip/pbuf.h>
+#include <lwip/sys.h>
+
+#include "micropython.h"
+#include "mpfirewallport.h"
+
+#define dlog(fmt, ...) do { \
+    printf("%s: %s:%d:%s: " fmt "\n", microkit_name, __FILE__, __LINE__, __func__, ##__VA_ARGS__); \
+} while (0);
+
+fw_webserver_interface_state_t webserver_state[FW_NUM_INTERFACES];
+
+extern fw_queue_t rx_active;
+extern fw_queue_t rx_free;
+extern fw_queue_t arp_req_queue;
+extern fw_queue_t arp_resp_queue;
+
+arp_packet_t arp_response_pkt = {0};
+
+static bool notify_rx = false;
+static bool notify_arp = false;
+
+/* Custom pbuf free function to free pbuf holding ARP packet */
+static void interface_free_arp_buffer(struct pbuf *buf) {
+    SYS_ARCH_DECL_PROTECT(old_level);
+    pbuf_custom_offset_t *pbuf = (pbuf_custom_offset_t *)buf;
+    SYS_ARCH_PROTECT(old_level);
+    pbuf_pool_free(pbuf);
+    SYS_ARCH_UNPROTECT(old_level);
+}
+
+static void firewall_interface_free_buffer(struct pbuf *buf) {
+    SYS_ARCH_DECL_PROTECT(old_level);
+    pbuf_custom_offset_t *pbuf = (pbuf_custom_offset_t *)buf;
+    SYS_ARCH_PROTECT(old_level);
+    net_buff_desc_t buffer = { pbuf->offset, 0 };
+    fw_enqueue(&rx_free, &buffer);
+    notify_rx = true;
+    pbuf_pool_free(pbuf);
+    SYS_ARCH_UNPROTECT(old_level);
+}
+
+static void fill_arp(uint32_t ip, uint8_t mac[ETH_HWADDR_LEN]) {
+    /* Fill ethernet header */
+    memcpy(arp_response_pkt.ethdst_addr, fw_config.interfaces[fw_config.interface].mac_addr, ETH_HWADDR_LEN);
+    memcpy(arp_response_pkt.ethsrc_addr, mac, ETH_HWADDR_LEN);
+    arp_response_pkt.type = HTONS(ETH_TYPE_ARP);
+    /* Fill ARP Packet */
+    arp_response_pkt.hwtype = HTONS(ETH_HWTYPE);
+    arp_response_pkt.proto = HTONS(ETH_TYPE_IP);
+    arp_response_pkt.hwlen = ETH_HWADDR_LEN;
+    arp_response_pkt.protolen = IPV4_PROTO_LEN;
+    arp_response_pkt.opcode = HTONS(ETHARP_OPCODE_REPLY);
+    memcpy(arp_response_pkt.hwsrc_addr, mac, ETH_HWADDR_LEN);
+    arp_response_pkt.ipsrc_addr = ip;
+    memcpy(arp_response_pkt.hwdst_addr, fw_config.interfaces[fw_config.interface].mac_addr, ETH_HWADDR_LEN);
+    arp_response_pkt.ipdst_addr = fw_config.interfaces[fw_config.interface].ip;
+    memset(&arp_response_pkt.padding, 0, 10);
+}
+
+bool mpfirewall_intercept_arp(struct pbuf *p) {
+    /* Check if this is an ARP request before transmitting through NIC */
+    arp_packet_t *arp = (arp_packet_t *)p->payload;
+    if (arp->type != HTONS(ETH_TYPE_ARP) || arp->opcode != HTONS(ETHARP_OPCODE_REQUEST)) {
+        return false;
+    }
+
+    /* ARP request will be discarded or handled through the ARP requester */
+    return true;
+}
+
+/** 
+ * Only invoked if p holds an ARP packet (i.e. firewall_catch_arp(p) == true).
+ * ARP packets are not transmitted directly, instead they are converted to ARP
+ * requests and passed to the ARP requester to handle.
+ */
+net_sddf_err_t mpfirewall_handle_arp(struct pbuf *p) {
+    /**
+     * Check if the destination ip is ours - if so, this packet is most likely
+     * an ARP probe. We should discard. 
+    */
+    arp_packet_t *arp = (arp_packet_t *)p->payload;
+    if (arp->ipdst_addr == fw_config.interfaces[fw_config.interface].ip) {
+        return SDDF_LWIP_ERR_OK;
+    }
+
+    fw_arp_request_t request = {arp->ipdst_addr, {0}, ARP_STATE_INVALID};
+    int err = fw_enqueue(&arp_req_queue, &request);
+    if (err) {
+        dlog("Could not enqueue arp request, queue is full");
+        return SDDF_LWIP_ERR_NO_BUF;
+    }
+
+    notify_arp = true;
+    return SDDF_LWIP_ERR_OK;
+}
+
+void mpfirewall_process_arp(void) {
+    while (!fw_queue_empty(&arp_resp_queue)) {
+        fw_arp_request_t response;
+        int err = fw_dequeue(&arp_resp_queue, &response);
+        assert(!err);
+
+        if (response.state == ARP_STATE_REACHABLE) {
+            fill_arp(response.ip, response.mac_addr);
+
+            if (FW_DEBUG_OUTPUT) {
+                dlog("Inputting ARP response for ip %s -> obtained MAC[0] = %x, MAC[5] = %x\n", ipaddr_to_string(response.ip, ip_addr_buf0), response.mac_addr[0], response.mac_addr[5]);
+            }
+
+            /* Input packet into lwip stack */
+            pbuf_custom_offset_t *pbuf = pbuf_pool_alloc();
+            if (!pbuf) {
+                return;
+            }
+            pbuf->custom.custom_free_function = interface_free_arp_buffer;
+
+            struct pbuf *p = pbuf_alloced_custom(
+                PBUF_RAW,
+                sizeof(arp_packet_t),
+                PBUF_REF,
+                &pbuf->custom,
+                &arp_response_pkt,
+                sizeof(arp_packet_t)
+            );
+
+            net_sddf_err_t net_err = sddf_lwip_input_pbuf(p);
+            if (net_err != SDDF_LWIP_ERR_OK) {
+                dlog("Failed to input ARP pbuf, error code %d\n", net_err);
+                pbuf_free(p);
+            }
+        }
+    }
+}
+
+void mpfirewall_process_rx(void) {
+    while (!fw_queue_empty(&rx_active) && !pbuf_pool_empty()) {
+        pbuf_custom_offset_t *pbuf = pbuf_pool_alloc();
+        if (!pbuf) {
+            return;
+        }
+
+        net_buff_desc_t buffer;
+        int err = fw_dequeue(&rx_active, &buffer);
+        assert(!err);
+
+        pbuf->offset = buffer.io_or_offset;
+        pbuf->custom.custom_free_function = firewall_interface_free_buffer;
+
+        struct pbuf *p = pbuf_alloced_custom(
+            PBUF_RAW,
+            buffer.len,
+            PBUF_REF,
+            &pbuf->custom,
+            (void *)(buffer.io_or_offset + fw_config.data.vaddr),
+            NET_BUFFER_SIZE
+        );
+
+        net_sddf_err_t net_err = sddf_lwip_input_pbuf(p);
+        if (net_err != SDDF_LWIP_ERR_OK) {
+            dlog("Failed to input firewall pbuf, error code %d\n", net_err);
+            pbuf_free(p);
+        }
+    }
+}
+
+void mpfirewall_handle_notify(void) {
+    if (notify_arp) {
+        notify_arp = false;
+        if (!microkit_have_signal) {
+            microkit_deferred_notify(fw_config.arp_queue.ch);
+        } else if (microkit_signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + fw_config.arp_queue.ch) {
+            microkit_notify(fw_config.arp_queue.ch);
+        }
+    }
+
+    if (notify_rx) {
+        notify_rx = false;
+        if (!microkit_have_signal) {
+            microkit_deferred_notify(fw_config.rx_free.ch);
+        } else if (microkit_signal_cap != BASE_OUTPUT_NOTIFICATION_CAP + fw_config.rx_free.ch) {
+            microkit_notify(fw_config.rx_free.ch);
+        }
+    }
+}
+
+void init_firewall_webserver(void) {
+    for (uint8_t i = 0; i < FW_NUM_INTERFACES; i++) {
+        webserver_state[i].routing_table = fw_config.interfaces[i].router.routing_table.vaddr;
+
+        for (uint8_t j = 0; j < fw_config.interfaces[i].num_filters; j++) {
+            fw_filter_state_init(&webserver_state[i].filter_states[j],
+                                    fw_config.interfaces[i].filters[j].rules.vaddr,
+                                    fw_config.interfaces[i].filters[j].rules_capacity, 0, 0, 0,
+                                    fw_config.interfaces[i].filters[j].default_action);
+        }
+    }
+}

--- a/components/micropython/mpfirewallport.h
+++ b/components/micropython/mpfirewallport.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sddf/network/lib_sddf_lwip.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/filter.h>
+#include <lions/firewall/routing.h>
+#include <lwip/pbuf.h>
+
+/**
+ * Firewall webserver configuration structure.
+ */
+extern fw_webserver_config_t fw_config;
+
+/**
+ * Firewall webserver data structure tracking the routing table and filter rules
+ * for each network interface.
+ */
+typedef struct fw_webserver_interface_state {
+    fw_routing_table_t *routing_table;
+  
+    fw_filter_state_t filter_states[FW_MAX_FILTERS];
+    uint16_t num_rules[FW_MAX_FILTERS];
+} fw_webserver_interface_state_t;
+
+extern fw_webserver_interface_state_t webserver_state[FW_NUM_INTERFACES];
+
+/**
+ * Checks whether the pbuf contains an ARP request. All ARP requests and
+ * responses in the firewall are handled by the ARP components, thus the
+ * webserver is not permitted to send ARP request packets out directly. Instead
+ * all ARP request packets are intercepted and enqueued in the ARP request queue
+ * shared with the routing component.
+ *
+ * @param p pbuf to check.
+ *
+ * @return whether pbuf contains an outgoing ARP request packet. 
+ */
+bool mpfirewall_intercept_arp(struct pbuf *p);
+
+/**
+ * Converts a pbuf containing an ARP request packet into a fw_arp_request_t and
+ * enqueues the request in the ARP requester component queue. All ARP requests
+ * and responses in the firewall are handled by the ARP components, thus the
+ * webserver is not permitted to send ARP request packets out directly. Instead
+ * all ARP request packets are intercepted and enqueued in the ARP request queue
+ * shared with the routing component.
+ *
+ * @param p pbuf containing ARP request packet.
+ *
+ * @return error status of operation. 
+ */
+net_sddf_err_t mpfirewall_handle_arp(struct pbuf *p);
+
+/**
+ * Processes the ARP response queue shared with the ARP requester component. ARP
+ * responses are converted into ARP ethernet packets and input into the LWIP
+ * network interface. Dequeues all ARP responses until queue is empty or the lib
+ * sDDF LWIP memory pool runs out.
+ */
+void mpfirewall_process_arp(void);
+
+/**
+ * Processes the Rx active packet queue shared with the routing component.
+ * Dequeues all available packets and inputs them into the LWIP network
+ * interface until queue is empty or the lib sDDF LWIP memory pool runs out.
+ */
+void mpfirewall_process_rx(void);
+
+/**
+ * Handles the sending of notifications to the ARP requester and firewall Rx
+ * virtualiser. Must be invoked at the end of each event handling loop and
+ * initialisation to ensure neighbouring components are scheduled to process
+ * their queues.
+ */
+void mpfirewall_handle_notify(void);
+
+/**
+ * Initialises firewall webserver data structures containing shared data with
+ * filter and routing components.
+ */
+void init_firewall_webserver(void);

--- a/examples/firewall/Makefile
+++ b/examples/firewall/Makefile
@@ -1,0 +1,42 @@
+#
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+ifeq ($(strip $(MICROKIT_SDK)),)
+$(error MICROKIT_SDK must be specified)
+endif
+override MICROKIT_SDK:=$(abspath ${MICROKIT_SDK})
+
+ifeq ($(strip $(FW_IOTGATE_IDX)),)
+$(error FW_IOTGATE_IDX must be specified within range 1-5)
+endif
+
+ifeq ($(strip $(LIBGCC)),)
+export LIBGCC:=$(dir $(realpath $(shell aarch64-none-elf-gcc --print-file-name libgcc.a)))
+endif
+ifeq ($(strip $(LIBMATH)),)
+export LIBMATH:=$(dir $(realpath $(shell aarch64-none-elf-gcc --print-file-name libm.a)))
+endif
+
+export MICROKIT_CONFIG ?= debug
+export BUILD_DIR ?= $(abspath build)
+export MICROKIT_BOARD := $(MICROKIT_BOARD)
+export FIREWALL_SRC_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+export LIONSOS := $(abspath ../..)
+
+IMAGE_FILE := $(BUILD_DIR)/firewall.img
+REPORT_FILE := $(BUILD_DIR)/report.txt
+nproc:= $(shell sh -c "if test -f /proc/cpuinfo; then grep processor /proc/cpuinfo | wc -l; else echo 2; fi")
+
+all: ${IMAGE_FILE}
+
+qemu ${IMAGE_FILE}: ${BUILD_DIR}/Makefile FORCE
+	${MAKE} -C ${BUILD_DIR} MICROKIT_SDK=${MICROKIT_SDK} $(notdir $@)
+
+${BUILD_DIR}/Makefile: firewall.mk
+	mkdir -p ${BUILD_DIR}
+	cp firewall.mk $@
+
+FORCE:

--- a/examples/firewall/arp/arp_requester.c
+++ b/examples/firewall/arp/arp_requester.c
@@ -1,0 +1,342 @@
+/*
+ * Copyright 2025, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <os/sddf.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/network/util.h>
+#include <sddf/serial/queue.h>
+#include <sddf/serial/config.h>
+#include <sddf/timer/client.h>
+#include <sddf/timer/config.h>
+#include <lions/firewall/arp.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/protocols.h>
+#include <lions/firewall/queue.h>
+#include <string.h>
+
+__attribute__((__section__(".net_client_config"))) net_client_config_t net_config;
+__attribute__((__section__(".serial_client_config"))) serial_client_config_t serial_config;
+__attribute__((__section__(".timer_client_config"))) timer_client_config_t timer_config;
+__attribute__((__section__(".fw_arp_requester_config"))) fw_arp_requester_config_t arp_config;
+
+net_queue_handle_t rx_queue;
+net_queue_handle_t tx_queue;
+
+serial_queue_handle_t serial_tx_queue_handle;
+
+/* Queues hold ARP requests/responses for router and webserver */
+fw_queue_t arp_req_queue[FW_NUM_ARP_REQUESTER_CLIENTS];
+fw_queue_t arp_resp_queue[FW_NUM_ARP_REQUESTER_CLIENTS];
+
+/* ARP table caches ARP request responses */
+fw_arp_table_t arp_table;
+
+/* Keep track of whether the tx virt requires notification */
+static bool transmitted;
+
+/* Keep track of which clients require notification */
+static bool notify_client[FW_NUM_ARP_REQUESTER_CLIENTS] = {false};
+
+#define ARP_MAX_RETRIES 5               /* How many times the ARP requester will send out an ARP request. */
+#define ARP_RETRY_TIMER_S 1             /* How often to retry an ARP request, in seconds. */
+#define ARP_RETRY_TIMER_NS (ARP_RETRY_TIMER_S * NS_IN_S)
+#define ARP_CACHE_LIFE_M 5              /* The lifetime of the ARP cache in minutes. After this time elapses, the cache is flushed. */
+#define ARP_CACHE_LIFE_NS ((ARP_CACHE_LIFE_M * 60) * NS_IN_S)
+#define ARP_TICKS_PER_FLUSH (ARP_CACHE_LIFE_NS / ARP_RETRY_TIMER_NS) /* Number of arp ticks per arp cache flushing. */
+
+/* Time that we will flush the arp queue (to the closest arp retry timer tick). */
+uint64_t ticks_to_flush = ARP_TICKS_PER_FLUSH;
+
+static void generate_arp(net_buff_desc_t *buffer, uint32_t ip)
+{
+    arp_packet_t *pkt = (arp_packet_t *)(net_config.tx_data.vaddr + buffer->io_or_offset);
+
+    /* Set the destination MAC address as the broadcast MAC address */
+    memset(&pkt->ethdst_addr, 0xFF, ETH_HWADDR_LEN);
+    memcpy(&pkt->ethsrc_addr, arp_config.mac_addr, ETH_HWADDR_LEN);
+    memcpy(&pkt->hwsrc_addr, arp_config.mac_addr, ETH_HWADDR_LEN);
+
+    pkt->type = HTONS(ETH_TYPE_ARP);
+    pkt->hwtype = HTONS(ETH_HWTYPE);
+    pkt->proto = HTONS(ETH_TYPE_IP);
+    pkt->hwlen = ETH_HWADDR_LEN;
+    pkt->protolen = IPV4_PROTO_LEN;
+    pkt->opcode = HTONS(ETHARP_OPCODE_REQUEST);
+
+    /* Memset the hardware src addr to 0 for ARP requests */
+    memset(&pkt->hwdst_addr, 0, ETH_HWADDR_LEN);
+    pkt->ipdst_addr = ip;
+    pkt->ipsrc_addr = arp_config.ip;
+    memset(&pkt->padding, 0, 10);
+
+    buffer->len = 56;
+}
+
+static void process_requests()
+{
+    for (uint8_t client = 0; client < arp_config.num_arp_clients; client++) {
+        while (!fw_queue_empty(&arp_req_queue[client]) && !net_queue_empty_free(&tx_queue)) {
+            fw_arp_request_t request;
+            int err = fw_dequeue(&arp_req_queue[client], &request);
+            assert(!err);
+
+            /* Check if an arp entry already exists */
+            fw_arp_entry_t *entry = fw_arp_table_find_entry(&arp_table, request.ip);
+            if (entry != NULL && entry->state != ARP_STATE_PENDING) {
+                /* Reply immediately */
+                fw_arp_request_t response = fw_arp_response_from_entry(entry);
+                fw_enqueue(&arp_resp_queue[client], &response);
+                fw_enqueue(&arp_resp_queue[client], &request);
+                notify_client[client] = true;
+                continue;
+            } else if (entry != NULL && entry->state == ARP_STATE_PENDING) {
+                /* Notify client upon response for existing ARP request */
+                entry->client |= BIT(client);
+                continue;
+            }
+            
+
+            /* Generate ARP request */
+            net_buff_desc_t buffer = {};
+            err = net_dequeue_free(&tx_queue, &buffer);
+            assert(!err);
+
+            generate_arp(&buffer, request.ip);
+            err = net_enqueue_active(&tx_queue, buffer);
+            assert(!err);
+
+            if (FW_DEBUG_OUTPUT) {
+                sddf_printf("%sARP requester processing client %u request for ip %s\n",
+                    fw_frmt_str[arp_config.interface], client,
+                    ipaddr_to_string(request.ip, ip_addr_buf0));
+            }
+
+            /* Create arp entry for request to store associated client */
+            fw_arp_error_t arp_err = fw_arp_table_add_entry(&arp_table, ARP_STATE_PENDING, request.ip, NULL, client);
+            if (arp_err == ARP_ERR_FULL) {
+                sddf_dprintf("%sARP REQUESTER LOG: Arp cache full, cannot enqueue entry!\n",
+                fw_frmt_str[arp_config.interface]);
+            }
+
+            transmitted = true;
+        }
+    }
+}
+
+static void process_responses()
+{
+    bool returned = false;
+    bool reprocess = true;
+    while (reprocess) {
+        while (!net_queue_empty_active(&rx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_active(&rx_queue, &buffer);
+            assert(!err);
+
+            arp_packet_t *pkt = (arp_packet_t *)(net_config.rx_data.vaddr + buffer.io_or_offset);
+            /* Check if packet is an ARP request */
+            if (pkt->type == HTONS(ETH_TYPE_ARP)) {
+                /* Check if it's a probe, ignore announcements */
+                if (pkt->opcode == HTONS(ETHARP_OPCODE_REPLY)) {
+                    /* Find the arp entry */
+                    fw_arp_entry_t *entry = fw_arp_table_find_entry(&arp_table, pkt->ipsrc_addr);
+                    if (entry != NULL) {
+                        /* This was a response to a request we sent, update entry */
+                        entry->state = ARP_STATE_REACHABLE;
+                        memcpy(&entry->mac_addr, &pkt->hwsrc_addr, ETH_HWADDR_LEN);
+
+                        /* Send to clients */
+                        for (uint8_t client = 0; client < arp_config.num_arp_clients; client++) {
+                            if (BIT(client) & entry->client) {
+                                fw_arp_request_t response = fw_arp_response_from_entry(entry);
+                                fw_enqueue(&arp_resp_queue[client], &response);
+                                notify_client[client] = true;
+                                if (FW_DEBUG_OUTPUT) {
+                                    sddf_printf("%sARP requester received response for client %u, ip %s. MAC[0] = %x, MAC[5] = %x\n",
+                                        fw_frmt_str[arp_config.interface], client, ipaddr_to_string(pkt->ipsrc_addr, ip_addr_buf0),
+                                        pkt->hwsrc_addr[0], pkt->hwsrc_addr[5]);
+                                }
+                            }
+                        }
+                    } else {
+                        /* Create a new entry */
+                        fw_arp_error_t arp_err = fw_arp_table_add_entry(&arp_table, ARP_STATE_REACHABLE, pkt->ipsrc_addr, pkt->hwsrc_addr, 0);
+                        if (arp_err == ARP_ERR_FULL) {
+                            sddf_dprintf("%sARP REQUESTER LOG: Arp cache full, cannot enqueue entry!\n", fw_frmt_str[arp_config.interface]);
+                        }
+                    }
+                }
+            }
+
+            buffer.len = 0;
+            err = net_enqueue_free(&rx_queue, buffer);
+            assert(!err);
+            returned = true;
+        }
+
+        net_request_signal_active(&rx_queue);
+        reprocess = false;
+
+        if (!net_queue_empty_active(&rx_queue)) {
+            net_cancel_signal_active(&rx_queue);
+            reprocess = true;
+        }
+    }
+
+    if (returned && net_require_signal_free(&rx_queue)) {
+        net_cancel_signal_free(&rx_queue);
+        microkit_deferred_notify(net_config.rx.id);
+    }
+}
+
+/* Returns the number of ARP entry retries. */
+static uint16_t process_retries(void)
+{
+    uint16_t pending_requests = 0;
+    for (uint16_t i = 0; i < arp_table.capacity; i++) {
+        fw_arp_entry_t *entry = arp_table.entries + i;
+        if (entry->state != ARP_STATE_PENDING) {
+            continue;
+        }
+
+        if (entry->num_retries >= ARP_MAX_RETRIES) {
+            /* Node is now considered unreachable */
+            entry->state = ARP_STATE_UNREACHABLE;
+
+            /* Generate ARP responses */
+            for (uint8_t client = 0; client < arp_config.num_arp_clients; client++) {
+                if (BIT(client) & entry->client) {
+                    fw_arp_request_t response = fw_arp_response_from_entry(entry);
+                    fw_enqueue(&arp_resp_queue[client], &response);
+                    notify_client[client] = true;
+                }
+            }
+        } else {
+            /* Resend the ARP request out to the network */
+
+            if (FW_DEBUG_OUTPUT) {
+                sddf_printf("%sARP requester attempting to resend request for ip %s\n",
+                    fw_frmt_str[arp_config.interface],
+                    ipaddr_to_string(entry->ip, ip_addr_buf0));
+            }
+
+            if (!net_queue_empty_free(&tx_queue)) {
+                net_buff_desc_t buffer = {0};
+                int err = net_dequeue_free(&tx_queue, &buffer);
+                assert(!err);
+
+                generate_arp(&buffer, entry->ip);
+                err = net_enqueue_active(&tx_queue, buffer);
+                assert(!err);
+                transmitted = true;
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sARP requester resent request for ip %s\n",
+                        fw_frmt_str[arp_config.interface],
+                        ipaddr_to_string(entry->ip, ip_addr_buf0));
+                }
+            }
+
+            /* Increment the number of retries */
+            entry->num_retries++;
+            pending_requests++;
+        }
+    }
+
+    return pending_requests;
+}
+
+/* Flush all non pending cache entries */
+static uint16_t arp_table_flush(void) {
+    uint16_t flushed = 0;
+    for (uint16_t i = 0; i < arp_table.capacity; i++) {
+        fw_arp_entry_t *entry = arp_table.entries + i;
+        if (entry->state == ARP_STATE_INVALID || entry->state == ARP_STATE_PENDING) {
+            continue;
+        }
+
+        entry->state = ARP_STATE_INVALID;
+        flushed++;
+    }
+
+    return flushed;
+}
+
+void init(void)
+{
+    assert(net_config_check_magic((void *)&net_config));
+
+    serial_queue_init(&serial_tx_queue_handle, serial_config.tx.queue.vaddr, serial_config.tx.data.size,
+        serial_config.tx.data.vaddr);
+    serial_putchar_init(serial_config.tx.id, &serial_tx_queue_handle);
+
+    net_queue_init(&rx_queue, net_config.rx.free_queue.vaddr, net_config.rx.active_queue.vaddr,
+        net_config.rx.num_buffers);
+    net_queue_init(&tx_queue, net_config.tx.free_queue.vaddr, net_config.tx.active_queue.vaddr,
+        net_config.tx.num_buffers);
+    net_buffers_init(&tx_queue, 0);
+
+    for (uint8_t client = 0; client < arp_config.num_arp_clients; client++) {
+        fw_queue_init(&arp_req_queue[client], arp_config.arp_clients[client].request.vaddr,
+            sizeof(fw_arp_request_t), arp_config.arp_clients[client].capacity);
+        fw_queue_init(&arp_resp_queue[client], arp_config.arp_clients[client].response.vaddr,
+            sizeof(fw_arp_request_t), arp_config.arp_clients[client].capacity);
+    }
+
+    fw_arp_table_init(&arp_table, (fw_arp_entry_t *)arp_config.arp_cache.vaddr, arp_config.arp_cache_capacity);
+
+    /* Set the first tick */
+    sddf_timer_set_timeout(timer_config.driver_id, ARP_RETRY_TIMER_NS);
+}
+
+void notified(microkit_channel ch)
+{
+    if (ch == arp_config.arp_clients[0].ch || (arp_config.num_arp_clients == 2 && ch == arp_config.arp_clients[1].ch)) {
+        process_requests();
+    } if (ch == net_config.rx.id) {
+        process_responses();
+    } else if (ch == timer_config.driver_id) {
+        ticks_to_flush--;
+        if (ticks_to_flush != 0) {
+            uint16_t retries = process_retries();
+
+            if (FW_DEBUG_OUTPUT && retries > 0) {
+                sddf_printf("%sARP requester processed %u retries for tick %lu\n",
+                    fw_frmt_str[arp_config.interface], retries, ticks_to_flush);
+            }
+
+        } else {
+            uint16_t flushed = arp_table_flush();
+
+            if (FW_DEBUG_OUTPUT && flushed > 0) {
+                sddf_printf("%sARP requester flushed %u entries from cache\n",
+                    fw_frmt_str[arp_config.interface], flushed);
+            }
+
+            ticks_to_flush = ARP_TICKS_PER_FLUSH;
+        }
+
+        sddf_timer_set_timeout(timer_config.driver_id, ARP_RETRY_TIMER_NS);
+    }
+
+    if (transmitted && net_require_signal_active(&tx_queue)) {
+        transmitted = false;
+        net_cancel_signal_active(&tx_queue);
+        microkit_deferred_notify(net_config.tx.id);
+    }
+
+    for (uint8_t client = 0; client < arp_config.num_arp_clients; client++) {
+        if (notify_client[client]) {
+            notify_client[client] = false;
+            microkit_notify(arp_config.arp_clients[client].ch);
+        }
+    }
+}

--- a/examples/firewall/arp/arp_responder.c
+++ b/examples/firewall/arp/arp_responder.c
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <os/sddf.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/network/util.h>
+#include <sddf/serial/queue.h>
+#include <sddf/serial/config.h>
+#include <sddf/timer/client.h>
+#include <sddf/timer/config.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/protocols.h>
+#include <string.h>
+
+__attribute__((__section__(".net_client_config"))) net_client_config_t net_config;
+__attribute__((__section__(".serial_client_config"))) serial_client_config_t serial_config;
+__attribute__((__section__(".timer_client_config"))) timer_client_config_t timer_config;
+__attribute__((__section__(".fw_arp_responder_config"))) fw_arp_responder_config_t arp_config;
+
+net_queue_handle_t rx_queue;
+net_queue_handle_t tx_queue;
+
+serial_queue_handle_t serial_tx_queue_handle;
+
+
+static int arp_reply(const uint8_t ethsrc_addr[ETH_HWADDR_LEN],
+                     const uint8_t ethdst_addr[ETH_HWADDR_LEN],
+                     const uint8_t hwsrc_addr[ETH_HWADDR_LEN], const uint32_t ipsrc_addr,
+                     const uint8_t hwdst_addr[ETH_HWADDR_LEN], const uint32_t ipdst_addr)
+{
+    if (net_queue_empty_free(&tx_queue)) {
+        sddf_dprintf("%sARP_RESPONDER LOG: Transmit free queue empty. Dropping reply\n",
+        fw_frmt_str[arp_config.interface]);
+        return -1;
+    }
+
+    net_buff_desc_t buffer;
+    int err = net_dequeue_free(&tx_queue, &buffer);
+    assert(!err);
+
+    arp_packet_t *reply = (arp_packet_t *)(net_config.tx_data.vaddr + buffer.io_or_offset);
+    memcpy(&reply->ethdst_addr, ethdst_addr, ETH_HWADDR_LEN);
+    memcpy(&reply->ethsrc_addr, ethsrc_addr, ETH_HWADDR_LEN);
+
+    reply->type = HTONS(ETH_TYPE_ARP);
+    reply->hwtype = HTONS(ETH_HWTYPE);
+    reply->proto = HTONS(ETH_TYPE_IP);
+    reply->hwlen = ETH_HWADDR_LEN;
+    reply->protolen = IPV4_PROTO_LEN;
+    reply->opcode = HTONS(ETHARP_OPCODE_REPLY);
+
+    memcpy(&reply->hwsrc_addr, hwsrc_addr, ETH_HWADDR_LEN);
+    reply->ipsrc_addr = ipsrc_addr;
+    memcpy(&reply->hwdst_addr, hwdst_addr, ETH_HWADDR_LEN);
+    reply->ipdst_addr = ipdst_addr;
+    memset(&reply->padding, 0, 10);
+
+    buffer.len = 56;
+    err = net_enqueue_active(&tx_queue, buffer);
+    assert(!err);
+
+    return 0;
+}
+
+static void receive(void)
+{
+    bool transmitted = false;
+    bool returned = false;
+    bool reprocess = true;
+    while (reprocess) {
+        while (!net_queue_empty_active(&rx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_active(&rx_queue, &buffer);
+            assert(!err);
+
+            /* Check if packet is an ARP request */
+            struct ethernet_header *ethhdr = (struct ethernet_header *)(net_config.rx_data.vaddr + buffer.io_or_offset);
+            if (ethhdr->type == HTONS(ETH_TYPE_ARP)) {
+                arp_packet_t *pkt = (arp_packet_t *)ethhdr;
+                /* Check if it's a probe, ignore announcements */
+                if (pkt->opcode == HTONS(ETHARP_OPCODE_REQUEST)) {
+                    /* Check the destination IP address */
+                    if (pkt->ipdst_addr == arp_config.ip) {
+
+                        if (FW_DEBUG_OUTPUT) {
+                            sddf_printf("%sARP Responder replying for ip %s\n", fw_frmt_str[arp_config.interface],
+                                ipaddr_to_string(pkt->ipdst_addr, ip_addr_buf0));
+                        }
+
+                        /* Reply with the MAC of the firewall */
+                        if (!arp_reply(arp_config.mac_addr, pkt->ethsrc_addr, arp_config.mac_addr, pkt->ipdst_addr,
+                                       pkt->hwsrc_addr, pkt->ipsrc_addr)) {
+                            transmitted = true;
+                        }
+                    }
+                }
+            }
+
+            buffer.len = 0;
+            err = net_enqueue_free(&rx_queue, buffer);
+            assert(!err);
+            returned = true;
+        }
+
+        net_request_signal_active(&rx_queue);
+        reprocess = false;
+
+        if (!net_queue_empty_active(&rx_queue)) {
+            net_cancel_signal_active(&rx_queue);
+            reprocess = true;
+        }
+    }
+
+    if (returned && net_require_signal_free(&rx_queue)) {
+        net_cancel_signal_free(&rx_queue);
+        microkit_notify(net_config.rx.id);
+    }
+
+    if (transmitted && net_require_signal_active(&tx_queue)) {
+        net_cancel_signal_active(&tx_queue);
+        microkit_deferred_notify(net_config.tx.id);
+    }
+}
+
+void init(void)
+{
+    assert(net_config_check_magic((void *)&net_config));
+
+    serial_queue_init(&serial_tx_queue_handle, serial_config.tx.queue.vaddr, serial_config.tx.data.size,
+        serial_config.tx.data.vaddr);
+    serial_putchar_init(serial_config.tx.id, &serial_tx_queue_handle);
+
+    net_queue_init(&rx_queue, net_config.rx.free_queue.vaddr, net_config.rx.active_queue.vaddr,
+                   net_config.rx.num_buffers);
+    net_queue_init(&tx_queue, net_config.tx.free_queue.vaddr, net_config.tx.active_queue.vaddr,
+                   net_config.tx.num_buffers);
+    net_buffers_init(&tx_queue, 0);
+}
+
+void notified(microkit_channel ch)
+{
+    if (ch == net_config.rx.id) {
+        receive();
+    }
+}

--- a/examples/firewall/filters/icmp_filter.c
+++ b/examples/firewall/filters/icmp_filter.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2025, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <os/sddf.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/network/util.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/filter.h>
+#include <lions/firewall/protocols.h>
+#include <lions/firewall/queue.h>
+
+__attribute__((__section__(".fw_filter_config"))) fw_filter_config_t filter_config;
+__attribute__((__section__(".net_client_config"))) net_client_config_t net_config;
+
+/* Queues for receiving and transmitting packets */
+net_queue_handle_t rx_queue;
+net_queue_handle_t tx_queue;
+fw_queue_t router_queue;
+
+/* Holds filtering rules and state */
+fw_filter_state_t filter_state;
+
+#define ICMP_FILTER_DUMMY_PORT 0
+
+static void filter(void)
+{
+    bool transmitted = false;
+    bool returned = false;
+    bool reprocess = true;
+    while (reprocess) {
+        while (!net_queue_empty_active(&rx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_active(&rx_queue, &buffer);
+            assert(!err);
+
+            void *pkt_vaddr = net_config.rx_data.vaddr + buffer.io_or_offset;
+            icmp_packet_t *icmp_hdr = (icmp_packet_t *)pkt_vaddr;
+
+            bool default_action = false;
+            uint16_t rule_id = 0;
+            fw_action_t action = fw_filter_find_action(&filter_state, icmp_hdr->src_ip, ICMP_FILTER_DUMMY_PORT,
+                                                                   icmp_hdr->dst_ip, ICMP_FILTER_DUMMY_PORT, &rule_id);
+
+            /* Perform the default action */
+            if (action == FILTER_ACT_NONE) {
+                default_action = true;
+                action = filter_state.default_action;
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sICMP filter found no match, performing default action %s: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.webserver.interface], fw_filter_action_str[action],
+                        ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                        ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
+                }
+            }
+            
+            /* Add an established connection in shared memory for corresponding filter */
+            if (action == FILTER_ACT_CONNECT) {
+                fw_filter_err_t fw_err = fw_filter_add_instance(&filter_state, icmp_hdr->src_ip, ICMP_FILTER_DUMMY_PORT,
+                                                                                icmp_hdr->dst_ip, ICMP_FILTER_DUMMY_PORT, default_action, rule_id);
+
+                if ((fw_err == FILTER_ERR_OKAY || fw_err == FILTER_ERR_DUPLICATE) && FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sICMP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                        ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
+                }
+
+                if (fw_err == FILTER_ERR_FULL) {
+                    sddf_printf("%sICMP FILTER LOG: could not establish connection for rule %u or default action %u: (ip %s, port %u) -> (ip %s, port %u): %s\n",
+                        fw_frmt_str[filter_config.webserver.interface],
+                        rule_id, default_action, ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                        ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT, fw_filter_err_str[fw_err]);
+                }
+            }
+
+            /* Transmit the packet to the routing component */
+            if (action == FILTER_ACT_CONNECT || action == FILTER_ACT_ESTABLISHED || action == FILTER_ACT_ALLOW) {
+                
+                /* Reset the checksum as it's recalculated in hardware */
+                icmp_hdr->checksum = 0;
+
+                err = fw_enqueue(&router_queue, &buffer);
+                assert(!err);
+                transmitted = true;
+
+                if (FW_DEBUG_OUTPUT) {
+                    if (action == FILTER_ACT_ALLOW || action == FILTER_ACT_CONNECT) {
+                        sddf_printf("%sICMP filter transmitting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                            ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
+                    } else if (action == FILTER_ACT_ESTABLISHED) {
+                        sddf_printf("%sICMP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                            ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
+                    }
+                }
+            } else if (action == FILTER_ACT_DROP) {
+                /* Return the buffer to the rx virtualiser */
+                err = net_enqueue_free(&rx_queue, buffer);
+                assert(!err);
+                returned = true;
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sICMP filter dropping via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                        ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
+                }
+            }
+        }
+
+        net_request_signal_active(&rx_queue);
+        reprocess = false;
+
+        if (!net_queue_empty_active(&rx_queue)) {
+            net_cancel_signal_active(&rx_queue);
+            reprocess = true;
+        }
+    }
+
+    if (returned) {
+        microkit_deferred_notify(net_config.rx.id);
+    }
+
+    if (transmitted) {
+        microkit_notify(filter_config.router.ch);
+    }
+}
+
+seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
+{
+    switch (microkit_msginfo_get_label(msginfo)) {
+    case FW_SET_DEFAULT_ACTION: {
+        fw_action_t action = seL4_GetMR(FILTER_ARG_ACTION);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sICMP filter changing default action from %u to %u\n",
+                fw_frmt_str[filter_config.webserver.interface], filter_state.default_action, action);
+        }
+
+        fw_filter_err_t err = fw_filter_update_default_action(&filter_state, action);
+        assert(err == FILTER_ERR_OKAY);
+
+        seL4_SetMR(FILTER_RET_ERR, err);
+        return microkit_msginfo_new(0, 1);
+    }
+    case FW_ADD_RULE: {
+        fw_action_t action = seL4_GetMR(FILTER_ARG_ACTION);
+        uint32_t src_ip = seL4_GetMR(FILTER_ARG_SRC_IP);
+        uint32_t dst_ip = seL4_GetMR(FILTER_ARG_DST_IP);
+        uint8_t src_subnet = seL4_GetMR(FILTER_ARG_SRC_SUBNET);
+        uint8_t dst_subnet = seL4_GetMR(FILTER_ARG_DST_SUBNET);
+        uint16_t rule_id = 0;
+        fw_filter_err_t err = fw_filter_add_rule(&filter_state, src_ip, ICMP_FILTER_DUMMY_PORT,
+            dst_ip, ICMP_FILTER_DUMMY_PORT, src_subnet, dst_subnet, true, true, action, &rule_id);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sICMP filter create rule %u: (ip %s, mask %u, port %u, any_port %u) - (%s) -> (ip %s, mask %u, port %u, any_port %u): %s\n",
+                fw_frmt_str[filter_config.webserver.interface], rule_id,
+                ipaddr_to_string(src_ip, ip_addr_buf0), src_subnet, ICMP_FILTER_DUMMY_PORT, false, fw_filter_action_str[action],
+                ipaddr_to_string(dst_ip, ip_addr_buf1), dst_subnet, ICMP_FILTER_DUMMY_PORT, false, fw_filter_err_str[err]);
+        }
+
+        seL4_SetMR(FILTER_RET_ERR, err);
+        seL4_SetMR(FILTER_RET_RULE_ID, rule_id);
+        return microkit_msginfo_new(0, 2);
+    }
+    case FW_DEL_RULE: {
+        uint16_t rule_id = seL4_GetMR(FILTER_ARG_RULE_ID);
+        fw_filter_err_t err = fw_filter_remove_rule(&filter_state, rule_id);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sICMP remove rule id %u: %s\n",
+                fw_frmt_str[filter_config.webserver.interface], rule_id, fw_filter_err_str[err]);
+        }
+
+        seL4_SetMR(FILTER_RET_ERR, err);
+        return microkit_msginfo_new(0, 1);
+    }
+    default:
+        sddf_printf("%sICMP FILTER LOG: unknown request %lu on channel %u\n",
+            fw_frmt_str[filter_config.webserver.interface],
+            microkit_msginfo_get_label(msginfo), ch);
+        break;
+    }
+
+    return microkit_msginfo_new(0, 0);
+}
+
+void notified(microkit_channel ch)
+{
+    if (ch == net_config.rx.id) {
+        filter();
+    } else {
+        sddf_dprintf("%sICMP FILTER LOG: Received notification on unknown channel: %d!\n",
+            fw_frmt_str[filter_config.webserver.interface], ch);
+    }
+}
+
+void init(void)
+{
+    assert(net_config_check_magic((void *)&net_config));
+
+    net_queue_init(&rx_queue, net_config.rx.free_queue.vaddr, net_config.rx.active_queue.vaddr,
+        net_config.rx.num_buffers);
+    
+    fw_queue_init(&router_queue, filter_config.router.queue.vaddr,
+        sizeof(net_buff_desc_t), filter_config.router.capacity);
+
+    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.webserver.rules_capacity,
+        filter_config.internal_instances.vaddr, filter_config.external_instances.vaddr, filter_config.instances_capacity,
+        (fw_action_t)filter_config.webserver.default_action);
+}

--- a/examples/firewall/filters/tcp_filter.c
+++ b/examples/firewall/filters/tcp_filter.c
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2025, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <os/sddf.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/network/util.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/filter.h>
+#include <lions/firewall/protocols.h>
+#include <lions/firewall/queue.h>
+
+__attribute__((__section__(".fw_filter_config"))) fw_filter_config_t filter_config;
+__attribute__((__section__(".net_client_config"))) net_client_config_t net_config;
+
+/* Queues for receiving and transmitting packets */
+net_queue_handle_t rx_queue;
+net_queue_handle_t tx_queue;
+fw_queue_t router_queue;
+
+/* Holds filtering rules and state */
+fw_filter_state_t filter_state;
+
+static void filter(void)
+{
+    bool transmitted = false;
+    bool returned = false;
+    bool reprocess = true;
+    while (reprocess) {
+        while (!net_queue_empty_active(&rx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_active(&rx_queue, &buffer);
+            assert(!err);
+
+            void *pkt_vaddr = net_config.rx_data.vaddr + buffer.io_or_offset;
+            ipv4_packet_t *ip_pkt = (ipv4_packet_t *)pkt_vaddr;
+            tcphdr_t *tcp_hdr = (tcphdr_t *)(pkt_vaddr + transport_layer_offset(ip_pkt));
+
+            bool default_action = false;
+            uint16_t rule_id = 0;
+            fw_action_t action = fw_filter_find_action(&filter_state, ip_pkt->src_ip, tcp_hdr->src_port,
+                                                                   ip_pkt->dst_ip, tcp_hdr->dst_port, &rule_id);
+
+            /* Perform the default action */
+            if (action == FILTER_ACT_NONE) {
+                default_action = true;
+                action = filter_state.default_action;
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sTCP filter found no match, performing default action %s: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.webserver.interface], fw_filter_action_str[action],
+                        ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), tcp_hdr->src_port,
+                        ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), tcp_hdr->dst_port);
+                }
+            }
+            
+            /* Add an established connection in shared memory for corresponding filter */
+            if (action == FILTER_ACT_CONNECT) {
+                fw_filter_err_t fw_err = fw_filter_add_instance(&filter_state, ip_pkt->src_ip, tcp_hdr->src_port,
+                                                                                ip_pkt->dst_ip, tcp_hdr->dst_port, default_action, rule_id);
+
+                if ((fw_err == FILTER_ERR_OKAY || fw_err == FILTER_ERR_DUPLICATE) && FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sTCP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), tcp_hdr->src_port,
+                        ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), tcp_hdr->dst_port);
+                }
+
+                if (fw_err == FILTER_ERR_FULL) {
+                    sddf_printf("%sTCP FILTER LOG: could not establish connection for rule %u: (ip %s, port %u) -> (ip %s, port %u): %s\n",
+                        fw_frmt_str[filter_config.webserver.interface],
+                        rule_id, ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), tcp_hdr->src_port,
+                        ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), tcp_hdr->dst_port, fw_filter_err_str[fw_err]);
+                }
+            }
+
+            /* Transmit the packet to the routing component */
+            if (action == FILTER_ACT_CONNECT || action == FILTER_ACT_ESTABLISHED || action == FILTER_ACT_ALLOW) {
+                /* Reset the checksum as it's recalculated in hardware */
+                tcp_hdr->check = 0;
+                
+                err = fw_enqueue(&router_queue, &buffer);
+                assert(!err);
+                transmitted = true;
+
+                if (FW_DEBUG_OUTPUT) {
+                    if (action == FILTER_ACT_ALLOW || action == FILTER_ACT_CONNECT) {
+                        sddf_printf("%sTCP filter transmitting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), tcp_hdr->src_port,
+                            ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), tcp_hdr->dst_port);
+                    } else if (action == FILTER_ACT_ESTABLISHED) {
+                        sddf_printf("%sTCP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), tcp_hdr->src_port,
+                            ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), tcp_hdr->dst_port);
+                    }
+                }
+            } else if (action == FILTER_ACT_DROP) {
+                /* Return the buffer to the rx virtualiser */
+                err = net_enqueue_free(&rx_queue, buffer);
+                assert(!err);
+                returned = true;
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sTCP filter dropping via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), tcp_hdr->src_port,
+                        ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), tcp_hdr->dst_port);
+                }
+            }
+        }
+
+        net_request_signal_active(&rx_queue);
+        reprocess = false;
+
+        if (!net_queue_empty_active(&rx_queue)) {
+            net_cancel_signal_active(&rx_queue);
+            reprocess = true;
+        }
+    }
+
+    if (returned) {
+        microkit_deferred_notify(net_config.rx.id);
+    }
+
+    if (transmitted) {
+        microkit_notify(filter_config.router.ch);
+    }
+}
+
+seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
+{
+    switch (microkit_msginfo_get_label(msginfo)) {
+    case FW_SET_DEFAULT_ACTION: {
+        fw_action_t action = seL4_GetMR(FILTER_ARG_ACTION);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sTCP filter changing default action from %u to %u\n",
+                fw_frmt_str[filter_config.webserver.interface], filter_state.default_action, action);
+        }
+
+        fw_filter_err_t err = fw_filter_update_default_action(&filter_state, action);
+        assert(err == FILTER_ERR_OKAY);
+
+        seL4_SetMR(FILTER_RET_ERR, err);
+        return microkit_msginfo_new(0, 1);
+    }
+    case FW_ADD_RULE: {
+        fw_action_t action = seL4_GetMR(FILTER_ARG_ACTION);
+        uint32_t src_ip = seL4_GetMR(FILTER_ARG_SRC_IP);
+        uint16_t src_port = seL4_GetMR(FILTER_ARG_SRC_PORT);
+        uint32_t dst_ip = seL4_GetMR(FILTER_ARG_DST_IP);
+        uint16_t dst_port = seL4_GetMR(FILTER_ARG_DST_PORT);
+        uint8_t src_subnet = seL4_GetMR(FILTER_ARG_SRC_SUBNET);
+        uint8_t dst_subnet = seL4_GetMR(FILTER_ARG_DST_SUBNET);
+        bool src_port_any = seL4_GetMR(FILTER_ARG_SRC_ANY_PORT);
+        bool dst_port_any = seL4_GetMR(FILTER_ARG_DST_ANY_PORT);
+        uint16_t rule_id = 0;
+        fw_filter_err_t err = fw_filter_add_rule(&filter_state, src_ip, src_port,
+            dst_ip, dst_port, src_subnet, dst_subnet, src_port_any, dst_port_any, action, &rule_id);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sTCP filter create rule %u: (ip %s, mask %u, port %u, any_port %u) - (%s) -> (ip %s, mask %u, port %u, any_port %u): %s\n",
+                fw_frmt_str[filter_config.webserver.interface], rule_id,
+                ipaddr_to_string(src_ip, ip_addr_buf0), src_subnet, src_port, src_port_any, fw_filter_action_str[action],
+                ipaddr_to_string(dst_ip, ip_addr_buf1), dst_subnet, dst_port, dst_port_any, fw_filter_err_str[err]);
+        }
+
+        seL4_SetMR(FILTER_RET_ERR, err);
+        seL4_SetMR(FILTER_RET_RULE_ID, rule_id);
+        return microkit_msginfo_new(0, 2);
+    }
+    case FW_DEL_RULE: {
+        uint16_t rule_id = seL4_GetMR(FILTER_ARG_RULE_ID);
+        fw_filter_err_t err = fw_filter_remove_rule(&filter_state, rule_id);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sTCP remove rule id %u: %s\n",
+                fw_frmt_str[filter_config.webserver.interface], rule_id, fw_filter_err_str[err]);
+        }
+
+        seL4_SetMR(FILTER_RET_ERR, err);
+        return microkit_msginfo_new(0, 1);
+    }
+    default:
+        sddf_printf("%sTCP FILTER LOG: unknown request %lu on channel %u\n",
+            fw_frmt_str[filter_config.webserver.interface],
+            microkit_msginfo_get_label(msginfo), ch);
+        break;
+    }
+
+    return microkit_msginfo_new(0, 0);
+}
+
+void notified(microkit_channel ch)
+{
+    if (ch == net_config.rx.id) {
+        filter();
+    } else {
+        sddf_dprintf("%sTCP FILTER LOG: Received notification on unknown channel: %d!\n",
+            fw_frmt_str[filter_config.webserver.interface], ch);
+    }
+}
+
+void init(void)
+{
+    assert(net_config_check_magic((void *)&net_config));
+
+    net_queue_init(&rx_queue, net_config.rx.free_queue.vaddr, net_config.rx.active_queue.vaddr,
+        net_config.rx.num_buffers);
+    
+    fw_queue_init(&router_queue, filter_config.router.queue.vaddr,
+        sizeof(net_buff_desc_t), filter_config.router.capacity);
+
+    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.webserver.rules_capacity,
+        filter_config.internal_instances.vaddr, filter_config.external_instances.vaddr, filter_config.instances_capacity,
+        (fw_action_t)filter_config.webserver.default_action);
+}

--- a/examples/firewall/filters/udp_filter.c
+++ b/examples/firewall/filters/udp_filter.c
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2025, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <os/sddf.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/network/util.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/filter.h>
+#include <lions/firewall/protocols.h>
+#include <lions/firewall/queue.h>
+
+__attribute__((__section__(".fw_filter_config"))) fw_filter_config_t filter_config;
+__attribute__((__section__(".net_client_config"))) net_client_config_t net_config;
+
+/* Queues for receiving and transmitting packets */
+net_queue_handle_t rx_queue;
+net_queue_handle_t tx_queue;
+fw_queue_t router_queue;
+
+/* Holds filtering rules and state */
+fw_filter_state_t filter_state;
+
+static void filter(void)
+{
+    bool transmitted = false;
+    bool returned = false;
+    bool reprocess = true;
+    while (reprocess) {
+        while (!net_queue_empty_active(&rx_queue)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_active(&rx_queue, &buffer);
+            assert(!err);
+
+            void *pkt_vaddr = net_config.rx_data.vaddr + buffer.io_or_offset;
+            ipv4_packet_t *ip_pkt = (ipv4_packet_t *)pkt_vaddr;
+            udphdr_t *udp_hdr = (udphdr_t *)(pkt_vaddr + transport_layer_offset(ip_pkt));
+
+            bool default_action = false;
+            uint16_t rule_id = 0;
+            fw_action_t action = fw_filter_find_action(&filter_state, ip_pkt->src_ip, udp_hdr->src_port,
+                                                                   ip_pkt->dst_ip, udp_hdr->dst_port, &rule_id);
+
+            /* Perform the default action */
+            if (action == FILTER_ACT_NONE) {
+                default_action = true;
+                action = filter_state.default_action;
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sUDP filter found no match, performing default action %s: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.webserver.interface], fw_filter_action_str[action],
+                        ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), udp_hdr->src_port,
+                        ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), udp_hdr->dst_port);
+                }
+            }
+            
+            /* Add an established connection in shared memory for corresponding filter */
+            if (action == FILTER_ACT_CONNECT) {
+                fw_filter_err_t fw_err = fw_filter_add_instance(&filter_state, ip_pkt->src_ip, udp_hdr->src_port,
+                                                                                ip_pkt->dst_ip, udp_hdr->dst_port, default_action, rule_id);
+
+                if ((fw_err == FILTER_ERR_OKAY || fw_err == FILTER_ERR_DUPLICATE) && FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sUDP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), udp_hdr->src_port,
+                        ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), udp_hdr->dst_port);
+                }
+
+                if (fw_err == FILTER_ERR_FULL) {
+                    sddf_printf("%sUDP FILTER LOG: could not establish connection for rule %u or default action %u: (ip %s, port %u) -> (ip %s, port %u): %s\n",
+                        fw_frmt_str[filter_config.webserver.interface],
+                        rule_id, default_action,
+                        ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), udp_hdr->src_port,
+                        ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), udp_hdr->dst_port, fw_filter_err_str[fw_err]);
+                }
+            }
+
+            /* Transmit the packet to the routing component */
+            if (action == FILTER_ACT_CONNECT || action == FILTER_ACT_ESTABLISHED || action == FILTER_ACT_ALLOW) {
+                
+                /* Reset the checksum as it's recalculated in hardware */
+                udp_hdr->check = 0;
+                err = fw_enqueue(&router_queue, &buffer);
+                assert(!err);
+                transmitted = true;
+
+                if (FW_DEBUG_OUTPUT) {
+                    if (action == FILTER_ACT_ALLOW || action == FILTER_ACT_CONNECT) {
+                        sddf_printf("%sUDP filter transmitting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), udp_hdr->src_port,
+                            ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), udp_hdr->dst_port);
+                    } else if (action == FILTER_ACT_ESTABLISHED) {
+                        sddf_printf("%sUDP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), udp_hdr->src_port,
+                            ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), udp_hdr->dst_port);
+                    }
+                }
+            } else if (action == FILTER_ACT_DROP) {
+                /* Return the buffer to the rx virtualiser */
+                err = net_enqueue_free(&rx_queue, buffer);
+                assert(!err);
+                returned = true;
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sUDP filter dropping via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.webserver.interface], rule_id, 
+                        ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), udp_hdr->src_port,
+                        ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), udp_hdr->dst_port);
+                }
+            }
+        }
+
+        net_request_signal_active(&rx_queue);
+        reprocess = false;
+
+        if (!net_queue_empty_active(&rx_queue)) {
+            net_cancel_signal_active(&rx_queue);
+            reprocess = true;
+        }
+    }
+
+    if (returned) {
+        microkit_deferred_notify(net_config.rx.id);
+    }
+
+    if (transmitted) {
+        microkit_notify(filter_config.router.ch);
+    }
+}
+
+seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
+{
+    switch (microkit_msginfo_get_label(msginfo)) {
+    case FW_SET_DEFAULT_ACTION: {
+        fw_action_t action = seL4_GetMR(FILTER_ARG_ACTION);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sUDP filter changing default action from %u to %u\n",
+                fw_frmt_str[filter_config.webserver.interface], filter_state.default_action, action);
+        }
+
+        fw_filter_err_t err = fw_filter_update_default_action(&filter_state, action);
+        assert(err == FILTER_ERR_OKAY);
+
+        seL4_SetMR(FILTER_RET_ERR, err);
+        return microkit_msginfo_new(0, 1);
+    }
+    case FW_ADD_RULE: {
+        fw_action_t action = seL4_GetMR(FILTER_ARG_ACTION);
+        uint32_t src_ip = seL4_GetMR(FILTER_ARG_SRC_IP);
+        uint16_t src_port = seL4_GetMR(FILTER_ARG_SRC_PORT);
+        uint32_t dst_ip = seL4_GetMR(FILTER_ARG_DST_IP);
+        uint16_t dst_port = seL4_GetMR(FILTER_ARG_DST_PORT);
+        uint8_t src_subnet = seL4_GetMR(FILTER_ARG_SRC_SUBNET);
+        uint8_t dst_subnet = seL4_GetMR(FILTER_ARG_DST_SUBNET);
+        bool src_port_any = seL4_GetMR(FILTER_ARG_SRC_ANY_PORT);
+        bool dst_port_any = seL4_GetMR(FILTER_ARG_DST_ANY_PORT);
+        uint16_t rule_id = 0;
+        fw_filter_err_t err = fw_filter_add_rule(&filter_state, src_ip, src_port,
+            dst_ip, dst_port, src_subnet, dst_subnet, src_port_any, dst_port_any, action, &rule_id);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sUDP filter create rule %u: (ip %s, mask %u, port %u, any_port %u) - (%s) -> (ip %s, mask %u, port %u, any_port %u): %s\n",
+                fw_frmt_str[filter_config.webserver.interface], rule_id,
+                ipaddr_to_string(src_ip, ip_addr_buf0), src_subnet, src_port, src_port_any, fw_filter_action_str[action],
+                ipaddr_to_string(dst_ip, ip_addr_buf1), dst_subnet, dst_port, dst_port_any, fw_filter_err_str[err]);
+        }
+    
+        seL4_SetMR(FILTER_RET_ERR, err);
+        seL4_SetMR(FILTER_RET_RULE_ID, rule_id);
+        return microkit_msginfo_new(0, 2);
+    }
+    case FW_DEL_RULE: {
+        uint16_t rule_id = seL4_GetMR(FILTER_ARG_RULE_ID);
+        fw_filter_err_t err = fw_filter_remove_rule(&filter_state, rule_id);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sUDP remove rule id %u: %s\n",
+                fw_frmt_str[filter_config.webserver.interface], rule_id, fw_filter_err_str[err]);
+        }
+
+        seL4_SetMR(FILTER_RET_ERR, err);
+        return microkit_msginfo_new(0, 1);
+    }
+    default:
+        sddf_printf("%sUDP FILTER LOG: unknown request %lu on channel %u\n",
+            fw_frmt_str[filter_config.webserver.interface],
+            microkit_msginfo_get_label(msginfo), ch);
+        break;
+    }
+
+    return microkit_msginfo_new(0, 0);
+}
+
+void notified(microkit_channel ch)
+{
+    if (ch == net_config.rx.id) {
+        filter();
+    } else {
+        sddf_dprintf("%sUDP FILTER LOG: Received notification on unknown channel: %d!\n",
+            fw_frmt_str[filter_config.webserver.interface], ch);
+    }
+}
+
+void init(void)
+{
+    assert(net_config_check_magic((void *)&net_config));
+
+    net_queue_init(&rx_queue, net_config.rx.free_queue.vaddr, net_config.rx.active_queue.vaddr,
+        net_config.rx.num_buffers);
+
+    fw_queue_init(&router_queue, filter_config.router.queue.vaddr,
+        sizeof(net_buff_desc_t),  filter_config.router.capacity);
+
+    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.webserver.rules_capacity,
+        filter_config.internal_instances.vaddr, filter_config.external_instances.vaddr, filter_config.instances_capacity,
+        (fw_action_t)filter_config.webserver.default_action);
+}

--- a/examples/firewall/firewall.mk
+++ b/examples/firewall/firewall.mk
@@ -1,0 +1,242 @@
+# Makefile for firewall.
+#
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This makefile will be copied into the Build directory and used from there.
+#
+BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+ARCH := $(shell grep 'CONFIG_SEL4_ARCH  ' $(BOARD_DIR)/include/kernel/gen_config.h | cut -d' ' -f4)
+SDDF := $(LIONSOS)/dep/sddf
+
+ifeq ($(strip $(MICROKIT_BOARD)), imx8mp_evk)
+	ETH_DRIV_DIR0 := imx
+	ETH_DRIV_DIR1 := dwmac-5.10a
+	SERIAL_DRIV_DIR := imx
+	TIMER_DRV_DIR := imx
+	CPU := cortex-a53
+else
+$(error Unsupported MICROKIT_BOARD given)
+endif
+
+TOOLCHAIN := clang
+CC := clang
+LD := ld.lld
+AR := llvm-ar
+RANLIB := llvm-ranlib
+OBJCOPY := llvm-objcopy
+OBJDUMP := llvm-objdump
+MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
+PYTHON ?= python3
+DTC := dtc
+
+ifeq ($(ARCH),aarch64)
+	CFLAGS_ARCH := -mcpu=$(CPU)
+	TARGET := aarch64-none-elf
+else ifeq ($(ARCH),riscv64)
+	CFLAGS_ARCH := -march=rv64imafdc
+	TARGET := riscv64-none-elf
+else
+$(error Unsupported ARCH given)
+endif
+
+ifeq ($(strip $(TOOLCHAIN)), clang)
+	CFLAGS_ARCH += -target $(TARGET)
+endif
+
+# Use sDDF custom libc for sDDF components
+SDDF_CUSTOM_LIBC := 1
+
+MICRODOT := $(LIONSOS)/dep/microdot/src
+FIREWALL_NET_COMPONENTS := $(FIREWALL_SRC_DIR)/net_components
+FIREWALL_FILTERS := $(FIREWALL_SRC_DIR)/filters
+FIREWALL_ICMP := $(FIREWALL_SRC_DIR)/icmp
+FIREWALL_ROUTING := $(FIREWALL_SRC_DIR)/routing
+FIREWALL_ARP := $(FIREWALL_SRC_DIR)/arp
+
+METAPROGRAM := $(FIREWALL_SRC_DIR)/meta.py
+DTS := $(SDDF)/dts/$(MICROKIT_BOARD).dts
+DTB := $(MICROKIT_BOARD).dtb
+
+SDFGEN_HELPER := $(FIREWALL_SRC_DIR)/sdfgen_helper.py
+# Macros needed by sdfgen helper to calculate config struct sizes
+SDFGEN_UNKOWN_MACROS := ETH_HWADDR_LEN=6 SDDF_NET_MAX_CLIENTS=64
+# Headers containing config structs and dependencies
+FIREWALL_CONFIG_HEADERS := $(SDDF)/include/sddf/resources/common.h \
+							$(SDDF)/include/sddf/resources/device.h \
+							$(LIONSOS)/include/lions/firewall/config.h
+
+IMAGES := arp_requester.elf arp_responder.elf routing.elf micropython.elf \
+		  eth_driver_imx.elf firewall_network_virt_rx.elf firewall_network_virt_tx.elf \
+		  eth_driver_dwmac-5.10a.elf timer_driver.elf serial_driver.elf serial_virt_tx.elf \
+		  icmp_filter.elf udp_filter.elf tcp_filter.elf icmp_module.elf
+
+DEPS := $(IMAGES:.elf=.d)
+
+SYSTEM_FILE := firewall.system
+
+CFLAGS := \
+	-mtune=$(CPU) \
+	-mstrict-align \
+	-ffreestanding \
+	-O2 \
+	-MD \
+	-MP \
+	-Wall \
+	-Wno-unused-function \
+	-I$(BOARD_DIR)/include \
+	$(CFLAGS_ARCH) \
+	-DBOARD_$(MICROKIT_BOARD) \
+	-I$(LIONSOS)/include \
+	-I$(SDDF)/include \
+	-I$(SDDF)/include/microkit
+
+LDFLAGS := -L$(BOARD_DIR)/lib
+LIBS := -lmicrokit -Tmicrokit.ld libsddf_util_debug.a
+
+IMAGE_FILE := firewall.img
+REPORT_FILE := report.txt
+
+all: $(IMAGE_FILE)
+$(IMAGES): libsddf_util_debug.a
+
+CHECK_FLAGS_BOARD_MD5:=.board_cflags-$(shell echo -- $(CFLAGS) $(BOARD) $(MICROKIT_CONFIG) $(FW_IOTGATE_IDX) | shasum | sed 's/ *-//')
+
+$(CHECK_FLAGS_BOARD_MD5):
+	-rm -f .board_cflags-*
+	touch $@
+
+vpath %.c $(SDDF) $(FIREWALL_SRC_DIR) $(FIREWALL_NET_COMPONENTS) $(FIREWALL_FILTERS) $(FIREWALL_ICMP) $(FIREWALL_ROUTING) $(FIREWALL_ARP)
+
+MICROPYTHON_LIBMATH := $(LIBMATH)
+MICROPYTHON_EXEC_MODULE := ui_server.py
+MICROPYTHON_FROZEN_MANIFEST := manifest.py
+MICROPYTHON_USER_C_MODULES := modfirewall.c
+
+$(MICROPYTHON_FROZEN_MANIFEST): $(MICROPYTHON_EXEC_MODULE)
+$(MICROPYTHON_EXEC_MODULE): $(MICRODOT)
+
+include $(LIONSOS)/components/micropython/micropython.mk
+
+%.py: $(FIREWALL_SRC_DIR)/%.py
+	cp $< $@
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+%.elf: %.o
+	$(LD) $(LDFLAGS) $< $(LIBS) -o $@
+
+# Components that print to serial require libsddf_util.a
+arp_requester.elf: arp_requester.o libsddf_util.a
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+arp_responder.elf: arp_responder.o libsddf_util.a
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+routing.elf: routing.o libsddf_util.a
+	$(LD) $(LDFLAGS) $^ $(LIBS) -o $@
+
+SDDF_MAKEFILES := $(SDDF)/util/util.mk \
+		  $(SDDF)/drivers/network/$(ETH_DRIV_DIR0)/eth_driver.mk \
+		  $(SDDF)/drivers/network/$(ETH_DRIV_DIR1)/eth_driver.mk \
+		  $(SDDF)/drivers/serial/$(SERIAL_DRIV_DIR)/serial_driver.mk \
+		  $(SDDF)/drivers/timer/$(TIMER_DRV_DIR)/timer_driver.mk \
+		  $(SDDF)/network/components/network_components.mk \
+		  $(SDDF)/serial/components/serial_components.mk
+
+include $(SDDF_MAKEFILES)
+include $(FIREWALL_NET_COMPONENTS)/firewall_network_components.mk
+
+$(DTB): $(DTS)
+	$(DTC) -q -I dts -O dtb $(DTS) > $(DTB)
+
+$(SYSTEM_FILE): $(METAPROGRAM) $(IMAGES) $(DTB) $(CHECK_FLAGS_BOARD_MD5)
+	$(PYTHON) $(SDFGEN_HELPER) --macros "$(SDFGEN_UNKOWN_MACROS)" --configs "$(FIREWALL_CONFIG_HEADERS)" --output $(FIREWALL_SRC_DIR)/config_structs.py
+	$(PYTHON) $(METAPROGRAM) --sddf $(SDDF) --board $(MICROKIT_BOARD) --dtb $(DTB) --output . --sdf $(SYSTEM_FILE) --objcopy $(OBJCOPY) --objdump $(OBJDUMP) --iotgate_idx $(FW_IOTGATE_IDX)
+	$(OBJCOPY) --update-section .device_resources=serial_driver_device_resources.data serial_driver.elf
+	$(OBJCOPY) --update-section .serial_driver_config=serial_driver_config.data serial_driver.elf
+	$(OBJCOPY) --update-section .serial_virt_tx_config=serial_virt_tx.data serial_virt_tx.elf
+	$(OBJCOPY) --update-section .device_resources=timer_driver_device_resources.data timer_driver.elf
+
+# Components receiving from or transmitting out net0
+	$(OBJCOPY) --update-section .device_resources=net_data0/ethernet_driver_dwmac-5.10a_device_resources.data eth_driver_dwmac-5.10a.elf
+	$(OBJCOPY) --update-section .net_driver_config=net_data0/net_driver.data eth_driver_dwmac-5.10a.elf
+
+	$(OBJCOPY) --update-section .net_virt_rx_config=net_data0/net_virt_rx.data firewall_network_virt_rx0.elf
+	$(OBJCOPY) --update-section .net_virt_tx_config=net_data0/net_virt_tx.data firewall_network_virt_tx0.elf
+
+# arp_requester1 receives requests from net1 router but transmits out net0
+	$(OBJCOPY) --update-section .net_client_config=net_data0/net_client_arp_requester1.data arp_requester1.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data0/net_client_arp_responder0.data arp_responder0.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data0/net_client_icmp_filter0.data icmp_filter0.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data0/net_client_udp_filter0.data udp_filter0.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data0/net_client_tcp_filter0.data tcp_filter0.elf
+	$(OBJCOPY) --update-section .ext_net_client_config=net_data0/net_client_icmp_module.data icmp_module.elf
+
+	$(OBJCOPY) --update-section .serial_client_config=serial_client_arp_responder0.data arp_responder0.elf
+	$(OBJCOPY) --update-section .serial_client_config=serial_client_arp_requester0.data arp_requester0.elf
+	$(OBJCOPY) --update-section .serial_client_config=serial_client_routing0.data routing0.elf
+
+	$(OBJCOPY) --update-section .timer_client_config=timer_client_arp_requester0.data arp_requester0.elf
+
+# Components receiving from or transmitting out net1
+	$(OBJCOPY) --update-section .device_resources=net_data1/ethernet_driver_imx_device_resources.data eth_driver_imx.elf
+	$(OBJCOPY) --update-section .net_driver_config=net_data1/net_driver.data eth_driver_imx.elf
+
+	$(OBJCOPY) --update-section .net_virt_rx_config=net_data1/net_virt_rx.data firewall_network_virt_rx1.elf
+	$(OBJCOPY) --update-section .net_virt_tx_config=net_data1/net_virt_tx.data firewall_network_virt_tx1.elf
+
+# arp_requester0 receives requests from net1 router but transmits out net1
+	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_arp_requester0.data arp_requester0.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_arp_responder1.data arp_responder1.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_icmp_filter1.data icmp_filter1.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_udp_filter1.data udp_filter1.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_tcp_filter1.data tcp_filter1.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_micropython.data micropython.elf
+	$(OBJCOPY) --update-section .int_net_client_config=net_data1/net_client_icmp_module.data icmp_module.elf
+
+	$(OBJCOPY) --update-section .lib_sddf_lwip_config=net_data1/lib_sddf_lwip_config_micropython.data micropython.elf
+
+	$(OBJCOPY) --update-section .serial_client_config=serial_client_arp_responder1.data arp_responder1.elf
+	$(OBJCOPY) --update-section .serial_client_config=serial_client_arp_requester1.data arp_requester1.elf
+	$(OBJCOPY) --update-section .serial_client_config=serial_client_routing1.data routing1.elf
+	$(OBJCOPY) --update-section .serial_client_config=serial_client_micropython.data micropython.elf
+
+	$(OBJCOPY) --update-section .timer_client_config=timer_client_micropython.data micropython.elf
+	$(OBJCOPY) --update-section .timer_client_config=timer_client_arp_requester1.data arp_requester1.elf
+
+$(IMAGE_FILE) $(REPORT_FILE): $(IMAGES) $(SYSTEM_FILE)
+	$(MICROKIT_TOOL) $(SYSTEM_FILE) --search-path $(BUILD_DIR) --board $(MICROKIT_BOARD) --config $(MICROKIT_CONFIG) -o $(IMAGE_FILE) -r $(REPORT_FILE)
+
+qemu: $(IMAGE_FILE)
+	$(QEMU) -machine virt,virtualization=on \
+			-cpu cortex-a53 \
+			-serial mon:stdio \
+			-device loader,file=$(IMAGE_FILE),addr=0x70000000,cpu-num=0 \
+			-m size=2G \
+			-nographic \
+			-device virtio-net-device,netdev=netdev0 \
+			-netdev user,id=netdev0,hostfwd=tcp::5555-10.0.2.16:80 \
+			-global virtio-mmio.force-legacy=false
+
+FORCE: ;
+
+$(LIONSOS)/dep/micropython/py/mkenv.mk $(LIONSOS)/dep/micropython/mpy-cross:
+	cd $(LIONSOS); git submodule update --init dep/micropython
+	cd $(LIONSOS)/dep/micropython && git submodule update --init lib/micropython-lib
+
+$(LIONSOS)/dep/libmicrokitco/Makefile:
+	cd $(LIONSOS); git submodule update --init dep/libmicrokitco
+
+$(MICRODOT):
+	cd $(LIONSOS); git submodule update --init dep/microdot
+
+$(MUSL_SRC)/Makefile:
+	cd $(LIONSOS); git submodule update --init dep/musllibc
+
+$(SDDF_MAKEFILES) &:
+	cd $(LIONSOS); git submodule update --init dep/sddf
+
+-include $(DEPS)

--- a/examples/firewall/icmp/icmp_module.c
+++ b/examples/firewall/icmp/icmp_module.c
@@ -1,0 +1,121 @@
+/*
+* Copyright 2025, UNSW
+* SPDX-License-Identifier: BSD-2-Clause
+*/
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <microkit.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/network/util.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/icmp.h>
+#include <lions/firewall/protocols.h>
+#include <lions/firewall/queue.h>
+
+__attribute__((__section__(".fw_icmp_module_config"))) fw_icmp_module_config_t icmp_config;
+__attribute__((__section__(".ext_net_client_config"))) net_client_config_t ext_net_config;
+__attribute__((__section__(".int_net_client_config"))) net_client_config_t int_net_config;
+
+net_client_config_t *net_configs[FW_NUM_INTERFACES] = {&ext_net_config, &int_net_config};
+
+net_queue_handle_t net_queue[FW_NUM_INTERFACES];
+fw_queue_t icmp_queue[FW_NUM_INTERFACES];
+
+static void generate_icmp(void)
+{
+    bool transmitted[FW_NUM_INTERFACES] = {false};
+    for (uint8_t out_int = 0; out_int < icmp_config.num_interfaces; out_int++) {
+        while (!fw_queue_empty(&icmp_queue[out_int]) && !net_queue_empty_free(&net_queue[out_int])) {
+            icmp_req_t req = {0};
+            int err = fw_dequeue(&icmp_queue[out_int], &req);
+            assert(!err);
+
+            net_buff_desc_t buffer = {};
+            err = net_dequeue_free(&net_queue[out_int], &buffer);
+            assert(!err);
+
+            icmp_packet_t *icmp_resp = (icmp_packet_t *) (net_configs[out_int]->tx_data.vaddr + buffer.io_or_offset);
+            /* Construct ethernet header */
+            memcpy(&icmp_resp->ethdst_addr, &req.hdr.ethsrc_addr, ETH_HWADDR_LEN);
+            memcpy(&icmp_resp->ethsrc_addr, &req.hdr.ethdst_addr, ETH_HWADDR_LEN);
+            icmp_resp->eth_type = HTONS(ETH_TYPE_IP);
+            
+            /* Construct IP packet */
+            icmp_resp->ihl_version = (4 << 4) | (5);
+            /* The differentiated services code 48 is for network control traffic. */
+            icmp_resp->tos = 48;
+
+            /**
+             * Hardcode the total length of a destination unreachable packet
+             * here. The total length of the IP packet and the ICMP packet,
+             * therefore we subtract the size of the ethernet header.
+             */
+             icmp_resp->tot_len = HTONS(sizeof(icmp_packet_t) - sizeof(struct ethernet_header));
+
+            /* Not fragmenting this IP packet. */
+            icmp_resp->id = HTONS(0);
+
+            /* 0x4000 sets the "Don't Fragment" Bit */
+            icmp_resp->frag_off = HTONS(0x4000);
+
+            /* Recommended inital value of ttl is 64 hops according to the TCP/IP spec. */
+            icmp_resp->ttl = 64;
+            icmp_resp->protocol = IPV4_PROTO_ICMP;
+            icmp_resp->check = 0;
+
+            /* Source of IP packet is the firewall */
+            icmp_resp->src_ip = icmp_config.ips[out_int];
+            icmp_resp->dst_ip = req.hdr.src_ip;
+            icmp_resp->type = req.type;
+            icmp_resp->code = req.code;
+
+            /* Set checksum to 0 for hardware calculation */
+            icmp_resp->checksum = 0;
+
+            /* IP header starts from ihl_version field */
+            memcpy(&icmp_resp->old_ip_hdr, &req.hdr.ihl_version, sizeof(ipv4hdr_t));
+            memcpy(&icmp_resp->old_data, req.data, FW_ICMP_OLD_DATA_LEN);
+
+            buffer.len = sizeof(icmp_packet_t);
+            err = net_enqueue_active(&net_queue[out_int], buffer);
+            transmitted[out_int] = true;
+            assert(!err);
+
+            if (FW_DEBUG_OUTPUT) {
+                sddf_printf("ICMP module sending packet for ip %s with type %u, code %u\n",
+                    ipaddr_to_string(icmp_resp->dst_ip, ip_addr_buf0), icmp_resp->type, icmp_resp->code);
+            }
+        }
+    }
+
+    for (uint8_t out_int = 0; out_int < icmp_config.num_interfaces; out_int++) { 
+        if (transmitted[out_int]) {
+            microkit_deferred_notify(net_configs[out_int]->tx.id);
+        }
+    }
+}
+
+void init(void)
+{
+    for (int i = 0; i < icmp_config.num_interfaces; i++) {
+        /* Setup the queue with the router. */
+        fw_queue_init(&icmp_queue[i], icmp_config.routers[i].queue.vaddr,
+            sizeof(icmp_req_t), icmp_config.routers[i].capacity);
+
+        /* Setup transmit queues with the transmit virtualisers. */
+        net_queue_init(&net_queue[i], net_configs[i]->tx.free_queue.vaddr,
+            net_configs[i]->tx.active_queue.vaddr, net_configs[i]->tx.num_buffers);
+        net_buffers_init(&net_queue[i], 0);
+    }
+}
+
+void notified(microkit_channel ch)
+{
+    generate_icmp();
+}

--- a/examples/firewall/manifest.py
+++ b/examples/firewall/manifest.py
@@ -1,0 +1,6 @@
+# Copyright 2024, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+
+include("$(MPY_DIR)/extmod/asyncio/manifest.py")
+package("microdot", base_path="$(PORT_DIR)/../../dep/microdot/src/")
+module("ui_server.py")

--- a/examples/firewall/meta.py
+++ b/examples/firewall/meta.py
@@ -1,0 +1,813 @@
+# Copyright 2025, UNSW SPDX-License-Identifier: BSD-2-Clause
+import argparse
+import subprocess
+from os import path
+from dataclasses import dataclass
+from typing import List
+from sdfgen import SystemDescription, Sddf, DeviceTree
+from ctypes import *
+from importlib.metadata import version
+import ipaddress
+
+assert version('sdfgen').split(".")[1] == "25", "Unexpected sdfgen version"
+
+from sdfgen_helper import *
+from config_structs import *
+
+ProtectionDomain = SystemDescription.ProtectionDomain
+MemoryRegion = SystemDescription.MemoryRegion
+Map = SystemDescription.Map
+Channel = SystemDescription.Channel
+
+page_size = 0x1000
+
+def round_up_to_Page(region_size: int) -> int:
+    if (region_size < page_size):
+        return page_size
+    elif (region_size % page_size == 0):
+        return region_size
+    else:
+        return region_size + (page_size - (region_size % page_size))
+
+# Name of the elf file which contains const variables holding the size of memory
+# region entries
+entry_size_extraction_elf = "routing.elf"
+class FirewallMemoryRegions():
+    # Store all config structs
+    all_mrs = []
+
+    def __init__(self, c_name, capacity, region_size_formula, entry_size = 0, region_size = 0):
+        # Name of variable in routing.elf holding size of table entry
+        self.c_name = c_name
+        # Capacity of data structure held in memory region
+        self.capacity = capacity
+        # Formula for calculating memory region size from class object
+        self.region_size_formula = region_size_formula
+        # Size of individual entries of data structure
+        self.entry_size = entry_size
+        # Size of region calculated using region_size_formula
+        self.region_size = region_size
+        FirewallMemoryRegions.all_mrs.append(self)
+        
+    def region_size(self):
+        property
+        if self.region_size == 0:
+            print("Extracted region size of memory region {self.c_name} was 0!")
+            sys.exit()
+        return self.region_size
+    
+    def calculate_size(self):
+        if self.entry_size == 0:
+            print("Entry size of memory region {self.c_name} was 0 during region size calculation!")
+            sys.exit()
+        self.region_size = round_up_to_Page(self.region_size_formula(self))
+        if self.region_size == 0:
+            print("Calculate region size of memory region {self.c_name} was 0!")
+            sys.exit()
+
+dma_buffer_queue_region = FirewallMemoryRegions("fw_buffer_queue_entry_size",
+                                                512,
+                                                lambda x: 16 + x.capacity * x.entry_size)
+
+dma_buffer_region = FirewallMemoryRegions(None,
+                                          dma_buffer_queue_region.capacity,
+                                          lambda x: x.capacity * x.entry_size,
+                                          2048)
+
+arp_queue_region = FirewallMemoryRegions("fw_arp_queue_entry_size",
+                                         512,
+                                         lambda x: 16 + x.capacity * x.entry_size)
+
+icmp_queue_region = FirewallMemoryRegions("fw_icmp_queue_entry_size",
+                                         128,
+                                         lambda x: 16 + x.capacity * x.entry_size)
+
+arp_cache_region = FirewallMemoryRegions("fw_arp_entry_size",
+                                         512,
+                                         lambda x: x.capacity * x.entry_size)
+
+arp_packet_queue_region = FirewallMemoryRegions("fw_arp_pkt_node_size",
+                                         dma_buffer_queue_region.capacity,
+                                         lambda x: x.capacity * x.entry_size)
+
+routing_table_region = FirewallMemoryRegions("fw_routing_entry_size",
+                                         256,
+                                         lambda x: 4 + x.capacity * x.entry_size)
+
+filter_rules_region = FirewallMemoryRegions("fw_rule_size",
+                                         256,
+                                         lambda x: x.capacity * x.entry_size)
+
+filter_instances_region = FirewallMemoryRegions("fw_instance_size",
+                                         512,
+                                         lambda x: x.capacity * x.entry_size)
+
+ext_net = 0
+int_net = 1
+
+FILTER_ACTION_ALLOW = 1
+FILTER_ACTION_DROP = 2
+FILTER_ACTION_CONNECT = 3
+
+def ip_to_int(ipString: str):
+    ipaddress.IPv4Address(ipString)
+     
+    # Switch little to big endian
+    ipSplit = ipString.split(".")
+    ipSplit.reverse()
+    reversedIp = ".".join(ipSplit)
+    return int(ipaddress.IPv4Address(reversedIp))
+
+macs = [
+    # IOTGATE1:
+    [[0x00, 0x01, 0xc0, 0x39, 0xd5, 0x18], # External network, ETH1
+    [0x00, 0x01, 0xc0, 0x39, 0xd5, 0x10]], # Internal network, ETH2
+    # IOTGATE2:
+    [[0x00, 0x01, 0xc0, 0x39, 0xd5, 0x1d], # External network, ETH1
+    [0x00, 0x01, 0xc0, 0x39, 0xd5, 0x15]], # Internal network, ETH2
+    # IOTGATE3:
+    [[0x00, 0x01, 0xc0, 0x3b, 0x3b, 0x8c], # External network, ETH1
+    [0x00, 0x01, 0xc0, 0x3b, 0x3b, 0x83]], # Internal network, ETH2
+    # IOTGATE4:
+    [[0x00, 0x01, 0xc0, 0x3b, 0x3b, 0x8a], # External network, ETH1
+    [0x00, 0x01, 0xc0, 0x3b, 0x3b, 0x85]], # Internal network, ETH2
+    # IOTGATE1:
+    [[0x00, 0x01, 0xc0, 0x3b, 0x3b, 0x80], # External network, ETH1
+    [0x00, 0x01, 0xc0, 0x3b, 0x3b, 0x79]], # Internal network, ETH2
+]
+
+subnet_bits = [12, 24]
+ips = [
+    # IOTGATE1: EXT = 16912556, INT = 18983104
+    [ip_to_int("172.16.2.1"), ip_to_int("192.168.1.1")],
+    # IOTGATE2
+    [ip_to_int("172.16.2.2"), ip_to_int("192.168.2.1")],
+    # IOTGATE3
+    [ip_to_int("172.16.2.3"), ip_to_int("192.168.3.1")],
+    # IOTGATE4
+    [ip_to_int("172.16.2.4"), ip_to_int("192.168.4.1")],
+    # IOTGATE5
+    [ip_to_int("172.16.2.5"), ip_to_int("192.168.5.1")],
+]
+
+arp_responder_protocol = 0x92
+arp_requester_protocol = 0x93
+
+@dataclass
+class Board:
+    name: str
+    arch: SystemDescription.Arch
+    paddr_top: int
+    serial: str
+    timer: str
+    ethernet0: str
+    ethernet1: str
+
+BOARDS: List[Board] = [
+    Board(
+        name="qemu_virt_aarch64",
+        arch=SystemDescription.Arch.AARCH64,
+        paddr_top=0x60_000_000,
+        serial="pl011@9000000",
+        timer="timer",
+        ethernet0="virtio_mmio@a003e00",
+        ethernet1="virtio_mmio@a002300"
+    ),
+    Board(
+        name="imx8mp_evk",
+        arch=SystemDescription.Arch.AARCH64,
+        paddr_top=0x70_000_000,
+        serial="soc@0/bus@30800000/spba-bus@30800000/serial@30890000",
+        timer="soc@0/bus@30000000/timer@302d0000",
+        ethernet0="soc@0/bus@30800000/ethernet@30be0000", #IMX
+        ethernet1="soc@0/bus@30800000/ethernet@30bf0000" #DWMAC
+    ),
+]
+
+# Create a firewall connection, which is a single queue and a channel. Data must
+# be created and mapped separately
+def fw_connection(pd1: SystemDescription.ProtectionDomain ,
+                  pd2: SystemDescription.ProtectionDomain,
+                  capacity: int, 
+                  region_size: int):
+    queue_name = "fw_queue_" + pd1.name + "_" + pd2.name
+    queue = MemoryRegion(sdf, queue_name, region_size)
+    sdf.add_mr(queue)
+
+    pd1_map = Map(queue, pd1.get_map_vaddr(queue), perms="rw")
+    pd1.add_map(pd1_map)
+    pd1_region = RegionResource(pd1_map.vaddr, region_size)
+
+    pd2_map = Map(queue, pd2.get_map_vaddr(queue), perms="rw")
+    pd2.add_map(pd2_map)
+    pd2_region = RegionResource(pd2_map.vaddr, region_size)
+
+    ch = Channel(pd1, pd2)
+    sdf.add_channel(ch)
+
+    pd1_conn = FwConnectionResource(pd1_region, capacity, ch.pd_a_id)
+    pd2_conn = FwConnectionResource(pd2_region, capacity, ch.pd_b_id)
+
+    return [pd1_conn, pd2_conn]
+
+# Create a firewall arp connection, which is two queues of the same capacity and
+# a channel
+def fw_arp_connection(pd1: SystemDescription.ProtectionDomain ,
+                      pd2: SystemDescription.ProtectionDomain,
+                      capacity: int,
+                      region_size: int):
+    req_queue_name = "fw_req_queue_" + pd1.name + "_" + pd2.name
+    req_queue = MemoryRegion(sdf, req_queue_name, region_size)
+    sdf.add_mr(req_queue)
+
+    pd1_req_map = Map(req_queue, pd1.get_map_vaddr(req_queue), perms="rw")
+    pd1.add_map(pd1_req_map)
+    pd1_req_region = RegionResource(pd1_req_map.vaddr, region_size)
+
+    pd2_req_map = Map(req_queue, pd2.get_map_vaddr(req_queue), perms="rw")
+    pd2.add_map(pd2_req_map)
+    pd2_req_region = RegionResource(pd2_req_map.vaddr, region_size)
+
+    res_queue_name = "fw_res_queue_" + pd1.name + "_" + pd2.name
+    res_queue = MemoryRegion(sdf, res_queue_name, region_size)
+    sdf.add_mr(res_queue)
+
+    pd1_res_map = Map(res_queue, pd1.get_map_vaddr(res_queue), perms="rw")
+    pd1.add_map(pd1_res_map)
+    pd1_res_region = RegionResource(pd1_res_map.vaddr, region_size)
+
+    pd2_res_map = Map(res_queue, pd2.get_map_vaddr(res_queue), perms="rw")
+    pd2.add_map(pd2_res_map)
+    pd2_res_region = RegionResource(pd2_res_map.vaddr, region_size)
+
+    ch = Channel(pd1, pd2)
+    sdf.add_channel(ch)
+
+    pd1_conn = FwArpConnection(pd1_req_region, pd1_res_region, capacity, ch.pd_a_id)
+    pd2_conn = FwArpConnection(pd2_req_region, pd2_res_region, capacity, ch.pd_b_id)
+
+    return [pd1_conn, pd2_conn]
+
+# Map a mr into a pd to create a firewall region
+def fw_region(pd: SystemDescription.ProtectionDomain,
+              mr: SystemDescription.MemoryRegion,
+              perms: str,
+              region_size: int):
+    pd_map = Map(mr, pd.get_map_vaddr(mr), perms=perms)
+    pd.add_map(pd_map)
+    region_resource = RegionResource(pd_map.vaddr, region_size)
+    
+    return region_resource
+
+# Map a physical mr into a pd to create a firewall device region
+def fw_device_region(pd: SystemDescription.ProtectionDomain, mr: SystemDescription.MemoryRegion, perms: str):
+    region = fw_region(pd, mr, perms, mr.size)
+    device_region = DeviceRegionResource(
+            region,
+            mr.paddr.value
+        )
+    return device_region
+
+# Create a firewall connection and map a physical mr to create a firewall data
+# connection
+def fw_data_connection(pd1: SystemDescription.ProtectionDomain ,
+                       pd2: SystemDescription.ProtectionDomain,
+                       capacity: int,
+                       queue_size: int,
+                       data: SystemDescription.MemoryRegion, 
+                       data_perms1: str,
+                       data_perms2: str):
+    connection = fw_connection(pd1, pd2, capacity, queue_size)
+    data_region1 = fw_device_region(pd1, data, data_perms1)
+    data_region2 = fw_device_region(pd2, data, data_perms2)
+
+    data_connection1 = FwDataConnectionResource(
+        connection[0],
+        data_region1
+    )
+    data_connection2 = FwDataConnectionResource(
+        connection[1],
+        data_region2
+    )
+
+    return [data_connection1, data_connection2]
+
+
+# Create a shared memory region between two pds from a mr
+def fw_shared_region(pd1: SystemDescription.ProtectionDomain,
+                     pd2: SystemDescription.ProtectionDomain, 
+                     perms1: str,
+                     perms2: str,
+                     name_prefix: str,
+                     region_size: int):
+    # Create rule memory region
+    region_name = name_prefix + "_" + pd1.name + "_" + pd2.name
+    mr = MemoryRegion(sdf, region_name, region_size)
+    sdf.add_mr(mr)
+
+    # Map rule into pd1
+    region1 = fw_region(pd1, mr, perms1, region_size)
+
+    # Map rule memory region into webserver
+    region2 = fw_region(pd2, mr, perms2, region_size)
+
+    return [region1, region2]
+
+def generate(sdf_file: str, output_dir: str, dtb: DeviceTree, iotgate_idx: int):
+    serial_node = dtb.node(board.serial)
+    assert serial_node is not None
+    ethernet_node0 = dtb.node(board.ethernet0)
+    assert ethernet_node0 is not None
+    ethernet_node1 = dtb.node(board.ethernet1)
+    assert ethernet_node1 is not None
+    timer_node = dtb.node(board.timer)
+    assert serial_node is not None
+    assert iotgate_idx is not None and iotgate_idx < 5 and iotgate_idx >= 0
+
+    common_pds = []
+
+    # Initialise network info dictionaries
+    networks = []
+    for i in range(2):
+        networks.append({
+            "num": i,
+            "out_num": (i + 1) % 2,
+            "mac": macs[iotgate_idx][i],
+            "ip": ips[iotgate_idx][i],
+            "out_dir": output_dir + "/net_data" + str(i),
+            "configs":{},
+            })
+        if not path.isdir(networks[i]["out_dir"]):
+            assert subprocess.run(["mkdir", networks[i]["out_dir"]]).returncode == 0
+
+    # Create timer subsystem
+    common_pds.append(ProtectionDomain("timer_driver", "timer_driver.elf", priority=101))
+    timer_system = Sddf.Timer(sdf, timer_node, common_pds[-1])
+
+    # Create serial subsystem
+    common_pds.append(ProtectionDomain("serial_driver", "serial_driver.elf", priority=100))
+    common_pds.append(ProtectionDomain("serial_virt_tx", "serial_virt_tx.elf", priority=99))
+    serial_system = Sddf.Serial(sdf, serial_node, common_pds[-2], common_pds[-1])
+
+    # Create network 0 pds
+    networks[ext_net]["driver"] = ProtectionDomain("ethernet_driver_dwmac-5.10a", "eth_driver_dwmac-5.10a.elf", priority=101, budget=100, period=400)
+    networks[int_net]["out_virt"] = ProtectionDomain("net_virt_tx0", "firewall_network_virt_tx0.elf", priority=100, budget=20000)
+    networks[ext_net]["in_virt"] = ProtectionDomain("net_virt_rx0", "firewall_network_virt_rx0.elf", priority=99)
+
+    networks[ext_net]["rx_dma_region"] = MemoryRegion(sdf, "rx_dma_region0", dma_buffer_region.region_size, physical=True)
+    sdf.add_mr(networks[ext_net]["rx_dma_region"])
+
+    # Create network 1 subsystem pds
+    networks[int_net]["driver"] = ProtectionDomain("ethernet_driver_imx", "eth_driver_imx.elf", priority=101, budget=100, period=400)
+    networks[ext_net]["out_virt"] = ProtectionDomain("net_virt_tx1", "firewall_network_virt_tx1.elf", priority=100, budget=20000)
+    networks[int_net]["in_virt"] = ProtectionDomain("net_virt_rx1", "firewall_network_virt_rx1.elf", priority=99)
+
+    networks[int_net]["rx_dma_region"] = MemoryRegion(sdf, "rx_dma_region1", dma_buffer_region.region_size, physical=True)
+    sdf.add_mr(networks[int_net]["rx_dma_region"])
+
+    # Create network subsystems
+    networks[ext_net]["in_net"] = Sddf.Net(sdf, ethernet_node1, networks[ext_net]["driver"], networks[int_net]["out_virt"],
+                                           networks[ext_net]["in_virt"], networks[ext_net]["rx_dma_region"])
+    networks[int_net]["out_net"] = networks[ext_net]["in_net"]
+
+
+    networks[int_net]["in_net"] = Sddf.Net(sdf, ethernet_node0, networks[int_net]["driver"], networks[ext_net]["out_virt"],
+                                           networks[int_net]["in_virt"], networks[int_net]["rx_dma_region"])
+    networks[ext_net]["out_net"] = networks[int_net]["in_net"]
+
+    # Create firewall pds
+    networks[ext_net]["router"] = ProtectionDomain("routing0", "routing0.elf", priority=97, budget=20000)
+    networks[int_net]["router"] = ProtectionDomain("routing1", "routing1.elf", priority=94, budget=20000)
+
+    networks[ext_net]["arp_resp"] = ProtectionDomain("arp_responder0", "arp_responder0.elf", priority=95, budget=20000)
+    networks[int_net]["arp_resp"] = ProtectionDomain("arp_responder1", "arp_responder1.elf", priority=93, budget=20000)
+
+    networks[ext_net]["arp_req"] = ProtectionDomain("arp_requester0", "arp_requester0.elf", priority=98, budget=20000)
+    networks[int_net]["arp_req"] = ProtectionDomain("arp_requester1", "arp_requester1.elf", priority=95, budget=20000)
+
+    # Create the webserver component
+    webserver = ProtectionDomain("micropython", "micropython.elf", priority=1, budget=20000)
+    common_pds.append(webserver)
+
+    # Webserver is a serial and timer client
+    serial_system.add_client(webserver)
+    timer_system.add_client(webserver)
+
+    # Create ICMP Module component
+    icmp_module = ProtectionDomain("icmp_module", "icmp_module.elf", priority=100, budget=20000)
+    common_pds.append(icmp_module)
+
+    networks[ext_net]["filters"] = {}
+    networks[ext_net]["filters"][0x01] = ProtectionDomain("icmp_filter0", "icmp_filter0.elf", priority=90, budget=20000)
+    networks[ext_net]["filters"][0x11] = ProtectionDomain("udp_filter0", "udp_filter0.elf", priority=91, budget=20000)
+    networks[ext_net]["filters"][0x06] = ProtectionDomain("tcp_filter0", "tcp_filter0.elf", priority=92, budget=20000)
+
+    networks[int_net]["filters"] = {}
+    networks[int_net]["filters"][0x01] = ProtectionDomain("icmp_filter1", "icmp_filter1.elf", priority=93, budget=20000)
+    networks[int_net]["filters"][0x11] = ProtectionDomain("udp_filter1", "udp_filter1.elf", priority=91, budget=20000)
+    networks[int_net]["filters"][0x06] = ProtectionDomain("tcp_filter1", "tcp_filter1.elf", priority=92, budget=20000)
+
+    for pd in common_pds:
+        sdf.add_pd(pd)
+
+    # Initial network loop to maintain client ordering consistency across
+    # networks
+    for network in networks:
+        # Add all pds to the system
+        for maybe_pd in network.values():
+            if type(maybe_pd) == ProtectionDomain:
+                # Drivers and routers do not need to be copied
+                if maybe_pd != network["driver"]:
+                    # remove x.elf suffix from elf
+                    copy_elf(maybe_pd.elf[:-5], maybe_pd.elf[:-5], network["num"])
+                sdf.add_pd(maybe_pd)
+
+        for filter_pd in network["filters"].values():
+            copy_elf(filter_pd.elf[:-5], filter_pd.elf[:-5], network["num"])
+            sdf.add_pd(filter_pd)
+
+        # Ensure arp requester is client 0 for each network
+        network["out_net"].add_client_with_copier(network["arp_req"])
+
+    # Webserver is a tx client of the internal network
+    networks[int_net]["in_net"].add_client_with_copier(webserver, rx=False)
+    
+    # Webserver uses lib sDDF LWIP
+    webserver_lib_sddf_lwip = Sddf.Lwip(sdf, networks[int_net]["in_net"], webserver)
+
+    # Webserver receives traffic from the internal -> external router
+    router_webserver_conn = fw_connection(networks[int_net]["router"], webserver,
+                                          dma_buffer_queue_region.capacity,
+                                          dma_buffer_queue_region.region_size)
+
+    # Webserver returns packets to interior rx virtualiser
+    webserver_in_virt_conn = fw_connection(webserver, networks[int_net]["in_virt"],
+                                           dma_buffer_queue_region.capacity,
+                                           dma_buffer_queue_region.region_size)
+
+    # Webserver needs access to rx dma region
+    webserver_data_region = fw_region(webserver, networks[int_net]["rx_dma_region"],
+                                      "rw", dma_buffer_queue_region.region_size)
+
+    # Webserver has arp channel for arp requests/responses
+    webserver_arp_conn = fw_arp_connection(webserver, networks[ext_net]["arp_req"],
+                                           arp_queue_region.capacity, arp_queue_region.region_size)
+
+    # ICMP Module needs to be able to transmit out of both NICs
+    networks[ext_net]["out_net"].add_client_with_copier(icmp_module, rx=False)
+    networks[int_net]["out_net"].add_client_with_copier(icmp_module, rx=False)
+
+    # ICMP Module needs to be connected to both routers.
+    icmp_int_router_conn = fw_connection(networks[int_net]["router"], icmp_module,
+                                        icmp_queue_region.capacity, icmp_queue_region.region_size)
+    icmp_ext_router_conn = fw_connection(networks[ext_net]["router"], icmp_module,
+                                        icmp_queue_region.capacity, icmp_queue_region.region_size)
+
+    icmp_module_config = FwIcmpModuleConfig(
+        ips[iotgate_idx],
+        [icmp_ext_router_conn[1], icmp_int_router_conn[1]],
+        2
+    )
+
+    networks[int_net]["icmp_module"] = icmp_int_router_conn[0]
+    networks[ext_net]["icmp_module"] = icmp_ext_router_conn[0]
+
+    # Create webserver config
+    webserver_config = FwWebserverConfig(
+        network["num"],
+        router_webserver_conn[1],
+        webserver_data_region,
+        webserver_in_virt_conn[0],
+        webserver_arp_conn[0],
+        [],
+    )
+
+    for network in networks:
+        router = network["router"]
+        out_virt = network["out_virt"]
+        in_virt = network["in_virt"]
+        arp_req = network["arp_req"]
+        arp_resp = network["arp_resp"]
+
+        # Create a firewall data connection between router and output virt with
+        # the rx dma region as data region
+        router_out_virt_conn = fw_data_connection(router, out_virt, dma_buffer_queue_region.capacity,
+                                                  dma_buffer_queue_region.region_size, 
+                                                  network["rx_dma_region"], "rw", "r")
+
+        # Create a firewall connection for output virt to return buffers to
+        # input virt
+        output_in_virt_conn = fw_connection(out_virt, in_virt, dma_buffer_queue_region.capacity,
+                                            dma_buffer_queue_region.region_size)
+        out_virt_in_virt_data_conn = FwDataConnectionResource(
+            output_in_virt_conn[0],
+            router_out_virt_conn[1].data
+        )
+
+        # Create output virt config
+        network["configs"][out_virt] = FwNetVirtTxConfig(
+            network["num"],
+            [router_out_virt_conn[1]],
+            [out_virt_in_virt_data_conn]
+        )
+
+        # Create a firewall connection for router to return free buffers to
+        # receive virtualiser on interior network
+        router_in_virt_conn = fw_connection(router, in_virt, dma_buffer_queue_region.capacity,
+                                            dma_buffer_queue_region.region_size)
+
+        # Create input virt config
+        network["configs"][in_virt] = FwNetVirtRxConfig(
+            network["num"],
+            [],
+            [router_in_virt_conn[1], output_in_virt_conn[1]]
+        )
+
+        # Add arp requester protocol for input virt client 0 - this is for the
+        # previously added arp requester which is always client 0
+        network["configs"][in_virt].active_client_protocols.append(arp_requester_protocol)
+
+        # Arp requester needs timer access to handle arp timeouts
+        timer_system.add_client(arp_req)
+
+        # Add arp responder filter pd as a network client
+        network["in_net"].add_client_with_copier(arp_resp)
+        network["configs"][in_virt].active_client_protocols.append(arp_responder_protocol)
+
+        # Create arp queue firewall connection
+        router_arp_conn = fw_arp_connection(router, arp_req, arp_queue_region.capacity,
+                                            arp_queue_region.region_size)
+
+        # Create arp cache
+        arp_cache = fw_shared_region(arp_req, router, "rw", "r",
+                                     "arp_cache", arp_cache_region.region_size)
+
+        # Create arp req config
+        network["configs"][arp_req] = FwArpRequesterConfig(
+            network["num"],
+            network["mac"],
+            network["ip"],
+            [router_arp_conn[1]],
+            arp_cache[0],
+            arp_cache_region.capacity
+        )
+
+        # Create arp resp config
+        network["configs"][arp_resp] = FwArpResponderConfig(
+            network["num"],
+            network["mac"],
+            network["ip"]
+        )
+
+        # Create arp packet queue
+        arp_packet_queue_mr = MemoryRegion(sdf, "arp_packet_queue_" + router.name,
+                                           arp_packet_queue_region.region_size)
+        sdf.add_mr(arp_packet_queue_mr)
+        arp_packet_queue = fw_region(router, arp_packet_queue_mr, "rw",
+                                     arp_packet_queue_region.region_size)
+
+        # Create routing table
+        routing_table = fw_shared_region(router, webserver, "rw", "r",
+                                         "routing_table",
+                                         routing_table_region.region_size)
+
+        # Create pp channel for routing table updates
+        router_update_ch = Channel(webserver, router, pp_a=True)
+        sdf.add_channel(router_update_ch)
+
+        # Create router webserver config
+        router_webserver_config = FwWebserverRouterConfig(
+            network["num"],
+            router_update_ch.pd_b_id,
+            routing_table[0],
+            routing_table_region.capacity
+        )
+
+        webserver_router_config = FwWebserverRouterConfig(
+            network["num"],
+            router_update_ch.pd_a_id,
+            routing_table[1],
+            routing_table_region.capacity
+        )
+
+        # Create router config
+        network["configs"][router] = FwRouterConfig(
+            network["num"],
+            network["mac"],
+            network["ip"],
+            ips[iotgate_idx][network["out_num"]],
+            subnet_bits[network["out_num"]],
+            router_in_virt_conn[0],
+            None,
+            router_out_virt_conn[0].conn,
+            router_out_virt_conn[0].data.region,
+            router_arp_conn[0],
+            arp_cache[1],
+            arp_cache_region.capacity,
+            arp_packet_queue,
+            router_webserver_config,
+            network["icmp_module"],
+            []
+        )
+        
+        webserver_interface_config = FwWebserverInterfaceConfig(
+            network["mac"],
+            network["ip"],
+            webserver_router_config,
+            []
+        )
+
+        for (protocol, filter_pd) in network["filters"].items():
+            # Create a firewall connection for filter to transmit buffers to
+            # router
+            filter_router_conn = fw_connection(filter_pd, router,
+                                               dma_buffer_queue_region.capacity,
+                                               dma_buffer_queue_region.region_size)
+
+            # Connect filter as rx only network client
+            network["in_net"].add_client_with_copier(filter_pd, tx=False)
+            network["configs"][in_virt].active_client_protocols.append(protocol)
+
+            # Create rule region
+            filter_rules = fw_shared_region(filter_pd, webserver, "rw",
+                                            "r", "filter_rules",
+                                            filter_rules_region.region_size)
+
+            # Create pp channel between webserver and filter for rule updates
+            filter_update_ch = Channel(webserver, filter_pd, pp_a = True)
+            sdf.add_channel(filter_update_ch)
+
+            # Create webserver configs
+            filter_webserver_config = FwWebserverFilterConfig(
+                network["num"],
+                protocol,
+                filter_update_ch.pd_b_id,
+                FILTER_ACTION_ALLOW,
+                filter_rules[0],
+                filter_rules_region.capacity
+            )
+
+            webserver_filter_config = FwWebserverFilterConfig(
+                network["num"],
+                protocol,
+                filter_update_ch.pd_a_id,
+                FILTER_ACTION_ALLOW,
+                filter_rules[1],
+                filter_rules_region.capacity
+            )
+
+            # Create filter config
+            network["configs"][filter_pd] = FwFilterConfig(
+                network["mac"],
+                network["ip"],
+                filter_instances_region.capacity,
+                filter_router_conn[0],
+                filter_webserver_config,
+                None,
+                None
+            )
+
+            network["configs"][router].filters.append((filter_router_conn[1]))
+            webserver_interface_config.filters.append(webserver_filter_config)
+        
+        webserver_config.interfaces.append(webserver_interface_config)
+
+        # Make router and arp components serial clients
+        serial_system.add_client(router)
+        serial_system.add_client(arp_req)
+        serial_system.add_client(arp_resp)
+
+        assert network["in_net"].connect()
+        assert network["in_net"].serialise_config(network["out_dir"])
+
+    # Add webserver as a free client of interior rx virt
+    networks[int_net]["configs"][networks[int_net]["in_virt"]].free_clients.append(webserver_in_virt_conn[1])
+
+    # Add webserver as an arp requester client outputting to the internal
+    # network
+    networks[ext_net]["configs"][networks[ext_net]["arp_req"]].arp_clients.append(webserver_arp_conn[1])
+
+    # Add a firewall connection to the webserver from the internal router for
+    # packet transmission
+    networks[int_net]["configs"][networks[int_net]["router"]].rx_active = router_webserver_conn[0]
+
+    # Add ICMP module
+
+
+    # Create filter instance regions
+    for (protocol, filter_pd) in networks[int_net]["filters"].items():
+        mirror_filter = networks[ext_net]["filters"][protocol]
+        int_instances = fw_shared_region(filter_pd, mirror_filter, "rw", "r",
+                                         "instances", filter_instances_region.region_size)
+        ext_instances = fw_shared_region(mirror_filter, filter_pd, "rw", "r",
+                                         "instances", filter_instances_region.region_size)
+
+        networks[int_net]["configs"][filter_pd].internal_instances = int_instances[0]
+        networks[int_net]["configs"][filter_pd].external_instances = ext_instances[1]
+        networks[ext_net]["configs"][mirror_filter].internal_instances = ext_instances[0]
+        networks[ext_net]["configs"][mirror_filter].external_instances = int_instances[1]
+
+    assert serial_system.connect()
+    assert serial_system.serialise_config(output_dir)
+    assert timer_system.connect()
+    assert timer_system.serialise_config(output_dir)
+
+    # Serialise webservers lib sDDF LWIP config
+    assert webserver_lib_sddf_lwip.connect()
+    assert webserver_lib_sddf_lwip.serialise_config(networks[int_net]["out_dir"])
+
+    for network in networks:
+        for pd, config in network["configs"].items():
+
+            data_path = network["out_dir"] + "/firewall_config_" + pd.name + ".data"
+            with open(data_path, "wb+") as f:
+                f.write(config.serialise())
+            update_elf_section(obj_copy, pd.elf,
+                               config.section_name,
+                               data_path)
+
+    data_path = output_dir + "/firewall_config_webserver.data"
+    with open(data_path, "wb+") as f:
+        f.write(webserver_config.serialise())
+    update_elf_section(obj_copy, webserver.elf,
+                       webserver_config.section_name,
+                       data_path)
+
+    data_path = output_dir + "/firewall_icmp_module_config.data"
+    with open(data_path, "wb+") as f:
+        f.write(icmp_module_config.serialise())
+    update_elf_section(obj_copy, icmp_module.elf,
+                       icmp_module_config.section_name,
+                       data_path)
+
+    with open(f"{output_dir}/{sdf_file}", "w+") as f:
+        f.write(sdf.render())
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dtb", required=True)
+    parser.add_argument("--sddf", required=True)
+    parser.add_argument("--board", required=True, choices=[b.name for b in BOARDS])
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--sdf", required=True)
+    parser.add_argument("--objcopy", required=True)
+    parser.add_argument("--objdump", required=True)
+    parser.add_argument("--iotgate_idx", required=True)
+    args = parser.parse_args()
+
+    board = next(filter(lambda b: b.name == args.board, BOARDS))
+
+    sdf = SystemDescription(board.arch, board.paddr_top)
+    sddf = Sddf(args.sddf)
+
+    global obj_copy
+    obj_copy = args.objcopy
+    
+    global obj_dump
+    obj_dump = args.objdump
+
+    with open(args.dtb, "rb") as f:
+        dtb = DeviceTree(f.read())
+    
+    # For memory regions holding arrays of firewall structs, we require the size
+    # of these structs to ensure our memory regions are the correct size. The
+    # elf file for the routing component defines a set of const size_t variables
+    # holding these sizes. We us objdump to extract these values.
+    
+    # Dump the elf file of the routing component
+    objdump_process = subprocess.run([obj_dump, "-DlSx", entry_size_extraction_elf],
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.PIPE,
+                                     check=True)
+    assert objdump_process.returncode == 0
+    
+    for mem_region in FirewallMemoryRegions.all_mrs:
+        entry_size = mem_region.entry_size
+        if entry_size == 0:
+            # Extract lines that hold the value of the size variable. NOTE: we
+            # assume the value is < UINT32_MAX
+            entry_size_lines = subprocess.run(["grep", "-A", "1", f"<{mem_region.c_name}>"],
+                                              input=objdump_process.stdout,
+                                              stdout=subprocess.PIPE,
+                                              stderr=subprocess.PIPE,
+                                              check=True)
+            # Isolate value line
+            size_line = subprocess.run(args=["grep", "0x"],
+                                              input=entry_size_lines.stdout,
+                                              stdout=subprocess.PIPE,
+                                              stderr=subprocess.PIPE,
+                                              check=True)
+            # Clean line
+            size_bytes = subprocess.run(["sed", "s/.*\\.word\\t*//g"],
+                                              input=size_line.stdout,
+                                              capture_output=True,
+                                              check=True)
+            
+            size_hex_string = str(size_bytes.stdout[:-1])[2:-1]
+            entry_size = int(size_hex_string, 16)
+            mem_region.entry_size = entry_size
+
+        mem_region.calculate_size()
+
+    generate(args.sdf, args.output, dtb, (int(args.iotgate_idx) - 1))

--- a/examples/firewall/net_components/firewall_network_components.mk
+++ b/examples/firewall/net_components/firewall_network_components.mk
@@ -1,0 +1,52 @@
+#
+# Copyright 2023, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This Makefile snippet builds the firewall network components
+# (for example, simple RX and TX virtualisers)
+# it should be included into your project Makefile
+#
+# NOTES:
+# Generates firewall_network_virt_rx.elf firewall_network_virt_tx.elf
+# Requires ${SDDF}/util/util.mk to build the utility library for debug output
+
+FIREWALL_NETWORK_COMPONENTS_DIR := $(abspath $(dir $(lastword ${MAKEFILE_LIST})))
+FIREWALL_NETWORK_IMAGES:= firewall_network_virt_rx.elf firewall_network_virt_tx.elf
+firewall_network/net_components/%.o: ${FIREWALL_COMPONENTS}/%.c
+	${CC} ${CFLAGS} -c -o $@ $<
+
+FIREWALL_NETWORK_COMPONENT_OBJ := $(addprefix firewall_network/net_components/, network_virt_tx.o network_virt_rx.o)
+
+CHECK_FIREWALL_NETWORK_FLAGS_MD5:=.firewall_network_cflags-$(shell echo -- ${CFLAGS} ${CFLAGS_network} | shasum | sed 's/ *-//')
+
+${CHECK_FIREWALL_NETWORK_FLAGS_MD5}:
+	-rm -f .firewall_network_cflags-*
+	touch $@
+
+#vpath %.c ${SDDF}/network/components
+
+
+${FIREWALL_NETWORK_IMAGES}: LIBS := libsddf_util_debug.a ${LIBS}
+
+${FIREWALL_NETWORK_COMPONENT_OBJ}: |firewall_network/net_components
+${FIREWALL_NETWORK_COMPONENT_OBJ}: ${CHECK_FIREWALL_NETWORK_FLAGS_MD5}
+${FIREWALL_NETWORK_COMPONENT_OBJ}: CFLAGS+=${CFLAGS_FIREWALL_NETWORK}
+
+firewall_network/net_components/firewall_network_virt_%.o: ${SDDF}/firewall_network/net_components/virt_%.c |firewall_network/net_components
+	${CC} ${CFLAGS} -c -o $@ $<
+
+%.elf: firewall_network/net_components/%.o |firewall_network/net_components
+	${LD} ${LDFLAGS} -o $@ $< ${LIBS}
+
+clean::
+	${RM} -f firewall_network_virt_[rt]x.[od]
+
+clobber::
+	${RM} -f ${FIREWALL_NETWORK_IMAGES}
+	rmdir firewall_network/net_components
+
+firewall_network/net_components:
+	mkdir -p $@
+
+-include ${FIREWALL_NETWORK_COMPONENTS_OBJS:.o=.d}

--- a/examples/firewall/net_components/firewall_network_virt_rx.c
+++ b/examples/firewall/net_components/firewall_network_virt_rx.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <os/sddf.h>
+#include <sddf/network/constants.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/util.h>
+#include <sddf/network/config.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/util/cache.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/protocols.h>
+#include <lions/firewall/queue.h>
+
+/* Used to signify that a packet has come in for the broadcast address and does not match with
+ * any particular client. */
+#define BROADCAST_ID (-2)
+
+__attribute__((__section__(".net_virt_rx_config"))) net_virt_rx_config_t config;
+__attribute__((__section__(".fw_net_virt_rx_config"))) fw_net_virt_rx_config_t fw_config;
+
+/* In order to handle broadcast packets where the same buffer is given to multiple clients
+  * we keep track of a reference count of each buffer and only hand it back to the driver once
+  * all clients have returned the buffer. */
+uint32_t *buffer_refs;
+
+net_queue_handle_t rx_queue_drv;
+net_queue_handle_t rx_queue_clients[SDDF_NET_MAX_CLIENTS];
+
+fw_queue_t fw_free_clients[FW_MAX_FW_CLIENTS];
+
+/* Boolean to indicate whether a packet has been enqueued into the driver's free queue during notification handling */
+static bool notify_drv;
+
+/* Return the client ID if the Mac address is a match to a client, return the broadcast ID if MAC address
+  is a broadcast address. */
+static int get_mac_addr_match(struct ethernet_header *buffer)
+{
+    for (int client = 0; client < config.num_clients; client++) {
+        bool match = true;
+        for (int i = 0; (i < ETH_HWADDR_LEN) && match; i++) {
+            if (buffer->dest.addr[i] != config.clients[client].mac_addr[i]) {
+                match = false;
+            }
+        }
+        if (match) {
+            return client;
+        }
+    }
+
+    bool broadcast_match = true;
+    for (int i = 0; (i < ETH_HWADDR_LEN) && broadcast_match; i++) {
+        if (buffer->dest.addr[i] != 0xFF) {
+            broadcast_match = false;
+        }
+    }
+    if (broadcast_match) {
+        return BROADCAST_ID;
+    }
+
+    return -1;
+}
+
+/* Returns the client ID if the protocol number is a match to the client. Handles ARP cases specially
+for requests/responses and does not use the standardised EthType protocol ID for these. */
+static int get_protocol_match(struct ethernet_header *buffer, uint16_t *protocol)
+{
+
+    /* @kwinter: For now we are using the range 0f 0x92 - 0xFC for non IP protocol
+    IDs in our client info structs as these are currently unused in the IP standard.
+    Maybe change this to something more robust in the future. */
+    uint16_t ethtype = buffer->type;
+    if (ethtype == HTONS(ETH_TYPE_ARP)) {
+        /* filter based on arp opcode */
+        arp_packet_t *pkt = (arp_packet_t *) buffer;
+        if (pkt->opcode == HTONS(ETHARP_OPCODE_REQUEST)) {
+            /* Requests go to the arp responder component */
+            *protocol = 0x92;
+        } else if (pkt->opcode == HTONS(ETHARP_OPCODE_REPLY)) {
+            /* Responses go to the arp requester component */
+            *protocol = 0x93;
+        }
+    } else if (ethtype == HTONS(ETH_TYPE_IP)) {
+        /* filter based on IP protocol */
+        ipv4_packet_t *pkt = (ipv4_packet_t *) buffer;
+        *protocol = pkt->protocol;
+    } else {
+        /* @kwinter: TODO: remove this, this should match with the router component for now. */
+        return -1;
+    }
+
+    for (int client = 0; client < config.num_clients; client++) {
+        if (fw_config.active_client_protocols[client] == *protocol) {
+            return client;
+        }
+    }
+
+    return -1;
+}
+
+static void rx_return(void)
+{
+    bool reprocess = true;
+    bool notify_clients[SDDF_NET_MAX_CLIENTS] = { false };
+    while (reprocess) {
+        while (!net_queue_empty_active(&rx_queue_drv)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_active(&rx_queue_drv, &buffer);
+            assert(!err);
+
+            buffer.io_or_offset = buffer.io_or_offset - config.data.io_addr;
+            uintptr_t buffer_vaddr = buffer.io_or_offset + (uintptr_t)config.data.region.vaddr;
+
+            /* Remove additional 4 byte ethernet header from NIC promiscuous mode */
+            buffer.len -= 4;
+
+            // Cache invalidate after DMA write, so we don't read stale data.
+            // This must be performed after the DMA write to avoid reading
+            // data that was speculatively fetched before the DMA write.
+            //
+            // We would invalidate if it worked in usermode. Alas, it
+            // does not -- see [1]. The fastest operation that works is a
+            // usermode CleanInvalidate (faster than a Invalidate via syscall).
+            //
+            // [1]: https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Instructions/DC-IVAC--Data-or-unified-Cache-line-Invalidate-by-VA-to-PoC
+            cache_clean_and_invalidate(buffer_vaddr, buffer_vaddr + buffer.len);
+            uint16_t protocol = 0;
+            int client = get_protocol_match((struct ethernet_header *) buffer_vaddr, &protocol);
+            if (client == BROADCAST_ID) {
+                int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;
+                assert(buffer_refs[ref_index] == 0);
+                // For broadcast packets, set the refcount to number of clients
+                // in the system. Only enqueue buffer back to driver if
+                // all clients have consumed the buffer.
+                buffer_refs[ref_index] = config.num_clients;
+
+                for (int i = 0; i < config.num_clients; i++) {
+                    err = net_enqueue_active(&rx_queue_clients[i], buffer);
+                    assert(!err);
+                    notify_clients[i] = true;
+                }
+                continue;
+            } else if (client >= 0) {
+                int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;
+                assert(buffer_refs[ref_index] == 0);
+                buffer_refs[ref_index] = 1;
+
+                err = net_enqueue_active(&rx_queue_clients[client], buffer);
+                assert(!err);
+                notify_clients[client] = true;
+            } else {
+                buffer.io_or_offset = buffer.io_or_offset + config.data.io_addr;
+                err = net_enqueue_free(&rx_queue_drv, buffer);
+                assert(!err);
+                notify_drv = true;
+            }
+        }
+
+        net_request_signal_active(&rx_queue_drv);
+        reprocess = false;
+
+        if (!net_queue_empty_active(&rx_queue_drv)) {
+            net_cancel_signal_active(&rx_queue_drv);
+            reprocess = true;
+        }
+    }
+
+    for (int client = 0; client < config.num_clients; client++) {
+        if (notify_clients[client] && net_require_signal_active(&rx_queue_clients[client])) {
+            net_cancel_signal_active(&rx_queue_clients[client]);
+            microkit_notify(config.clients[client].conn.id);
+        }
+    }
+}
+
+static void rx_provide(void)
+{
+    for (int client = 0; client < config.num_clients; client++) {
+        bool reprocess = true;
+        while (reprocess) {
+            while (!net_queue_empty_free(&rx_queue_clients[client])) {
+                net_buff_desc_t buffer;
+                int err = net_dequeue_free(&rx_queue_clients[client], &buffer);
+                assert(!err);
+                assert(!(buffer.io_or_offset % NET_BUFFER_SIZE)
+                       && (buffer.io_or_offset < NET_BUFFER_SIZE * rx_queue_clients[client].capacity));
+
+                int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;
+                assert(buffer_refs[ref_index] != 0);
+
+                buffer_refs[ref_index]--;
+
+                if (buffer_refs[ref_index] != 0) {
+                    continue;
+                }
+
+                // To avoid having to perform a cache clean here we ensure that
+                // the DMA region is only mapped in read only. This avoids the
+                // case where pending writes are only written to the buffer
+                // memory after DMA has occured.
+                buffer.io_or_offset = buffer.io_or_offset + config.data.io_addr;
+                err = net_enqueue_free(&rx_queue_drv, buffer);
+                assert(!err);
+                notify_drv = true;
+            }
+
+            net_request_signal_free(&rx_queue_clients[client]);
+            reprocess = false;
+
+            if (!net_queue_empty_free(&rx_queue_clients[client])) {
+                net_cancel_signal_free(&rx_queue_clients[client]);
+                reprocess = true;
+            }
+        }
+    }
+
+    for (int client = 0; client < fw_config.num_free_clients; client++) {
+        while (!fw_queue_empty(&fw_free_clients[client])) {
+            net_buff_desc_t buffer;
+            int err = fw_dequeue(&fw_free_clients[client], &buffer);
+            assert(!err);
+            assert(!(buffer.io_or_offset % NET_BUFFER_SIZE)
+                    && (buffer.io_or_offset < NET_BUFFER_SIZE * fw_free_clients[client].capacity));
+
+            int ref_index = buffer.io_or_offset / NET_BUFFER_SIZE;
+            assert(buffer_refs[ref_index] != 0);
+
+            buffer_refs[ref_index]--;
+
+            if (buffer_refs[ref_index] != 0) {
+                continue;
+            }
+
+            // To avoid having to perform a cache clean here we ensure that
+            // the DMA region is only mapped in read only. This avoids the
+            // case where pending writes are only written to the buffer
+            // memory after DMA has occured.
+            buffer.io_or_offset = buffer.io_or_offset + config.data.io_addr;
+            err = net_enqueue_free(&rx_queue_drv, buffer);
+            assert(!err);
+            notify_drv = true;
+        }
+    }
+
+    if (notify_drv && net_require_signal_free(&rx_queue_drv)) {
+        net_cancel_signal_free(&rx_queue_drv);
+        microkit_deferred_notify(config.driver.id);
+        notify_drv = false;
+    }
+}
+
+void notified(microkit_channel ch)
+{
+    rx_return();
+    rx_provide();
+}
+
+void init(void)
+{
+    assert(net_config_check_magic((void *)&config));
+
+    buffer_refs = config.buffer_metadata.vaddr;
+
+    /* Set up driver queues */
+    net_queue_init(&rx_queue_drv, config.driver.free_queue.vaddr, config.driver.active_queue.vaddr,
+                   config.driver.num_buffers);
+    net_buffers_init(&rx_queue_drv, config.data.io_addr);
+
+    /* Set up net client queues */
+    for (int i = 0; i < config.num_clients; i++) {
+        net_queue_init(&rx_queue_clients[i], config.clients[i].conn.free_queue.vaddr,
+                       config.clients[i].conn.active_queue.vaddr, config.clients[i].conn.num_buffers);
+    }
+
+    /* Set up firewall queues */
+    for (int i = 0; i < fw_config.num_free_clients; i++) {
+        fw_queue_init(&fw_free_clients[i], fw_config.free_clients[i].queue.vaddr,
+            sizeof(net_buff_desc_t), fw_config.free_clients[i].capacity);
+    }
+
+    if (net_require_signal_free(&rx_queue_drv)) {
+        net_cancel_signal_free(&rx_queue_drv);
+        microkit_deferred_notify(config.driver.id);
+    }
+}

--- a/examples/firewall/net_components/firewall_network_virt_tx.c
+++ b/examples/firewall/net_components/firewall_network_virt_tx.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2024, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <os/sddf.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/util/cache.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/queue.h>
+
+__attribute__((__section__(".net_virt_tx_config"))) net_virt_tx_config_t config;
+__attribute__((__section__(".fw_net_virt_tx_config"))) fw_net_virt_tx_config_t fw_config;
+
+net_queue_handle_t tx_queue_drv;
+net_queue_handle_t tx_queue_clients[SDDF_NET_MAX_CLIENTS];
+
+fw_queue_t fw_free_clients[FW_MAX_FW_CLIENTS];
+fw_queue_t fw_active_clients[FW_MAX_FW_CLIENTS];
+
+static int extract_offset_net_client(uintptr_t *phys)
+{
+    for (int client = 0; client < config.num_clients; client++) {
+        if (*phys >= config.clients[client].data.io_addr
+            && *phys
+                   < config.clients[client].data.io_addr + tx_queue_clients[client].capacity * NET_BUFFER_SIZE) {
+            *phys = *phys - config.clients[client].data.io_addr;
+            return client;
+        }
+    }
+    return -1;
+}
+
+static int extract_offset_fw_client(uintptr_t *phys)
+{
+    for (int client = 0; client < fw_config.num_free_clients; client++) {
+        if (*phys >= fw_config.free_clients[client].data.io_addr
+            && *phys
+                   < fw_config.free_clients[client].data.io_addr + fw_free_clients[client].capacity * NET_BUFFER_SIZE) {
+            *phys = *phys - fw_config.free_clients[client].data.io_addr;
+            return client;
+        }
+    }
+    return -1;
+}
+
+static void tx_provide(void)
+{
+    bool enqueued = false;
+    for (int client = 0; client < config.num_clients; client++) {
+        bool reprocess = true;
+        while (reprocess) {
+            while (!net_queue_empty_active(&tx_queue_clients[client])) {
+                net_buff_desc_t buffer;
+                int err = net_dequeue_active(&tx_queue_clients[client], &buffer);
+                assert(!err);
+
+                if (buffer.io_or_offset % NET_BUFFER_SIZE
+                    || buffer.io_or_offset >= NET_BUFFER_SIZE * tx_queue_clients[client].capacity) {
+                    sddf_dprintf("%sVIRT TX LOG: Client provided offset %lx which is not buffer aligned or outside of buffer region\n",
+                                 fw_frmt_str[fw_config.interface],
+                                 buffer.io_or_offset);
+                    err = net_enqueue_free(&tx_queue_clients[client], buffer);
+                    assert(!err);
+                    continue;
+                }
+
+                uintptr_t buffer_vaddr = buffer.io_or_offset + (uintptr_t)config.clients[client].data.region.vaddr;
+                cache_clean(buffer_vaddr, buffer_vaddr + buffer.len);
+                buffer.io_or_offset = buffer.io_or_offset + config.clients[client].data.io_addr;
+
+                err = net_enqueue_active(&tx_queue_drv, buffer);
+                assert(!err);
+                enqueued = true;
+            }
+
+            net_request_signal_active(&tx_queue_clients[client]);
+            reprocess = false;
+
+            if (!net_queue_empty_active(&tx_queue_clients[client])) {
+                net_cancel_signal_active(&tx_queue_clients[client]);
+                reprocess = true;
+            }
+        }
+    }
+
+    for (int client = 0; client < fw_config.num_active_clients; client++) {
+        while (!fw_queue_empty(&fw_active_clients[client])) {
+            net_buff_desc_t buffer;
+            int err = fw_dequeue(&fw_active_clients[client], &buffer);
+            assert(!err);
+
+            assert(buffer.io_or_offset % NET_BUFFER_SIZE == 0 && 
+                   buffer.io_or_offset < NET_BUFFER_SIZE * fw_active_clients[client].capacity);
+
+            uintptr_t buffer_vaddr = buffer.io_or_offset + (uintptr_t)fw_config.active_clients[client].data.region.vaddr;
+            cache_clean(buffer_vaddr, buffer_vaddr + buffer.len);
+            buffer.io_or_offset = buffer.io_or_offset + fw_config.active_clients[client].data.io_addr;
+
+            err = net_enqueue_active(&tx_queue_drv, buffer);
+            assert(!err);
+            enqueued = true;
+        }
+    }
+
+    if (enqueued && net_require_signal_active(&tx_queue_drv)) {
+        net_cancel_signal_active(&tx_queue_drv);
+        microkit_deferred_notify(config.driver.id);
+    }
+}
+
+static void tx_return(void)
+{
+    bool reprocess = true;
+    bool notify_net_clients[SDDF_NET_MAX_CLIENTS] = { false };
+    bool notify_fw_clients[SDDF_NET_MAX_CLIENTS] = { false };
+    while (reprocess) {
+        while (!net_queue_empty_free(&tx_queue_drv)) {
+            net_buff_desc_t buffer;
+            int err = net_dequeue_free(&tx_queue_drv, &buffer);
+            assert(!err);
+
+            int client = extract_offset_net_client(&buffer.io_or_offset);
+            if (client >= 0) {
+
+
+                err = net_enqueue_free(&tx_queue_clients[client], buffer);
+                assert(!err);
+                notify_net_clients[client] = true;
+                continue;
+            }
+            client = extract_offset_fw_client(&buffer.io_or_offset);
+            assert(client >= 0);
+
+
+            err = fw_enqueue(&fw_free_clients[client], &buffer);
+            assert(!err);
+            notify_fw_clients[client] = true;
+        }
+
+        net_request_signal_free(&tx_queue_drv);
+        reprocess = false;
+
+        if (!net_queue_empty_free(&tx_queue_drv)) {
+            net_cancel_signal_free(&tx_queue_drv);
+            reprocess = true;
+        }
+    }
+
+    for (int client = 0; client < config.num_clients; client++) {
+        if (notify_net_clients[client] && net_require_signal_free(&tx_queue_clients[client])) {
+            net_cancel_signal_free(&tx_queue_clients[client]);
+            microkit_notify(config.clients[client].conn.id);
+        }
+    }
+
+    for (int client = 0; client < fw_config.num_free_clients; client++) {
+        if (notify_fw_clients[client]) {
+            microkit_notify(fw_config.free_clients[client].conn.ch);
+        }
+    }
+}
+
+void notified(microkit_channel ch)
+{
+    tx_return();
+    tx_provide();
+}
+
+void init(void)
+{
+    assert(net_config_check_magic(&config));
+
+    /* Set up driver queues */
+    net_queue_init(&tx_queue_drv, config.driver.free_queue.vaddr, config.driver.active_queue.vaddr,
+                   config.driver.num_buffers);
+
+    for (int i = 0; i < config.num_clients; i++) {
+        net_queue_init(&tx_queue_clients[i], config.clients[i].conn.free_queue.vaddr,
+                       config.clients[i].conn.active_queue.vaddr, config.clients[i].conn.num_buffers);
+    }
+
+    /* Set up firewall queues */
+    for (int i = 0; i < fw_config.num_active_clients; i++) {
+        fw_queue_init(&fw_active_clients[i], fw_config.active_clients[i].conn.queue.vaddr,
+            sizeof(net_buff_desc_t), fw_config.active_clients[i].conn.capacity);
+    }
+
+    for (int i = 0; i < fw_config.num_free_clients; i++) {
+        fw_queue_init(&fw_free_clients[i], fw_config.free_clients[i].conn.queue.vaddr,
+            sizeof(net_buff_desc_t), fw_config.free_clients[i].conn.capacity);
+    }
+    tx_provide();
+}

--- a/examples/firewall/routing/routing.c
+++ b/examples/firewall/routing/routing.c
@@ -1,0 +1,469 @@
+/*
+ * Copyright 2025, UNSW
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <os/sddf.h>
+#include <sddf/util/util.h>
+#include <sddf/util/printf.h>
+#include <sddf/network/queue.h>
+#include <sddf/network/config.h>
+#include <sddf/network/util.h>
+#include <sddf/serial/queue.h>
+#include <sddf/serial/config.h>
+#include <lions/firewall/arp.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/filter.h>
+#include <lions/firewall/protocols.h>
+#include <lions/firewall/queue.h>
+#include <lions/firewall/routing.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/icmp.h>
+#include <string.h>
+
+__attribute__((__section__(".serial_client_config"))) serial_client_config_t serial_config;
+__attribute__((__section__(".fw_router_config"))) fw_router_config_t router_config;
+
+/* Port that the webserver is on. */
+#define WEBSERVER_PROTOCOL 0x06
+#define WEBSERVER_PORT 80
+
+serial_queue_handle_t serial_tx_queue_handle;
+
+/* DMA buffer data structures */
+fw_queue_t fw_filters[FW_MAX_FILTERS]; /* Filter queues to
+                                               * receive packets */
+fw_queue_t rx_free; /* Queue to return free rx buffers */
+fw_queue_t tx_active; /* Queue to transmit packets out the network */
+fw_queue_t webserver; /* Queue to route to webserver */
+uintptr_t data_vaddr; /* Virtual address or rx buffer data region */
+fw_queue_t icmp_queue; /* Queue to transmit ICMP requests to
+                                 * the ICMP module. */
+
+/* Arp request/entry data structures */
+fw_queue_t arp_req_queue;
+fw_queue_t arp_resp_queue;
+fw_arp_table_t arp_table; /* ARP table holding all known ARP entries */
+pkts_waiting_t pkt_waiting_queue; /* Queue holding packets awaiting
+                                   * arp responses */
+
+/* Routing data structures */
+fw_routing_table_t *routing_table; /* Table holding next hop data for subnets */
+
+/* Booleans to keep track of which components need to be notified */
+static bool tx_net; /* Packet has been transmitted to the network tx
+                     * virtualiser */
+static bool tx_webserver; /* Packet has been transmitted to the webserver */
+static bool returned; /* Buffer has been returned to the rx virtualiser */
+static bool notify_arp; /* Arp request has been enqueued */
+static bool notify_icmp; /* Request has been enqueued to ICMP module */
+
+/* Enqueue a request to the ICMP module to transmit a destination unreachable
+packet back to source */
+static int enqueue_icmp_unreachable(net_buff_desc_t buffer)
+{
+    uintptr_t pkt_vaddr = data_vaddr + buffer.io_or_offset;
+    ipv4_packet_t *ip_pkt = (ipv4_packet_t *)(pkt_vaddr);
+    icmp_req_t req = {0};
+    req.type = ICMP_DEST_UNREACHABLE;
+    req.code = ICMP_DEST_HOST_UNREACHABLE;
+
+    /* copy packet and 8 bytes of data */
+    memcpy(&req.hdr, ip_pkt, sizeof(ipv4_packet_t));
+    if (buffer.len >= (sizeof(ipv4_packet_t) + FW_ICMP_OLD_DATA_LEN)) {
+        memcpy(req.data, (void *)(pkt_vaddr + sizeof(ipv4_packet_t)), FW_ICMP_OLD_DATA_LEN);
+    }
+    int err = fw_enqueue(&icmp_queue, &req);
+    if (!err) {
+        notify_icmp = true;
+    }
+
+    return err;
+}
+
+static void transmit_packet(net_buff_desc_t buffer,
+                           uint8_t *mac_addr)
+{
+    uintptr_t pkt_vaddr = data_vaddr + buffer.io_or_offset;
+    ipv4_packet_t *ip_pkt = (ipv4_packet_t *)(pkt_vaddr);
+
+    memcpy(&ip_pkt->ethdst_addr, mac_addr, ETH_HWADDR_LEN);
+    memcpy(&ip_pkt->ethsrc_addr, router_config.mac_addr, ETH_HWADDR_LEN);
+    ip_pkt->check = 0;
+
+    /* Transmit packet out the NIC */
+    if (FW_DEBUG_OUTPUT) {
+        sddf_printf("%sRouter sending packet for ip %s with buffer number %lu\n",
+            fw_frmt_str[router_config.webserver.interface],
+            ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf0),
+            buffer.io_or_offset/NET_BUFFER_SIZE);
+    }
+
+    int err = fw_enqueue(&tx_active, &buffer);
+    assert(!err);
+    tx_net = true;
+}
+
+static void process_arp_waiting(void)
+{
+    while (!fw_queue_empty(&arp_resp_queue)) {
+        fw_arp_request_t response; 
+        int err = fw_dequeue(&arp_resp_queue, &response);
+        assert(!err);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sRouter dequeuing response for ip %s and MAC[0] = %x, MAC[5] = %x\n",
+                fw_frmt_str[router_config.webserver.interface],
+                ipaddr_to_string(response.ip, ip_addr_buf0),
+                        response.mac_addr[0], response.mac_addr[5]);
+        }
+
+        /* Check that we actually have a packet waiting. */
+        pkt_waiting_node_t *root = pkt_waiting_find_node(&pkt_waiting_queue, response.ip);
+        if (!root) {
+            continue;
+        }
+
+        /* Send or drop all matching ip packets */
+        if (response.state == ARP_STATE_UNREACHABLE) {
+            /* Invalid response, drop packet associated with the IP address */
+            pkt_waiting_node_t *node = root;
+            for (uint16_t i = 0; i < root->num_children; i++) {
+                err = enqueue_icmp_unreachable(node->buffer);
+                if (FW_DEBUG_OUTPUT && err) {
+                    sddf_dprintf("%sROUTING LOG: Could not enqueue ICMP unreachable!\n",
+                        fw_frmt_str[router_config.webserver.interface]);
+                }
+                err = fw_enqueue(&rx_free, &node->buffer);
+                assert(!err);
+                node = pkts_waiting_next_child(&pkt_waiting_queue, node);
+            }
+        } else {
+            /* Substitute the MAC address and send packets out of the NIC */
+            pkt_waiting_node_t *node = root;
+            for (uint16_t i = 0; i < root->num_children + 1; i++) {
+                transmit_packet(node->buffer, response.mac_addr);
+                node = pkts_waiting_next_child(&pkt_waiting_queue, node);
+            }
+        }
+        /* Free the packet waiting nodes */
+        fw_routing_err_t routing_err = pkts_waiting_free_parent(&pkt_waiting_queue, root);
+        assert(routing_err == ROUTING_ERR_OKAY);
+    }
+}
+
+static void route(void)
+{
+    for (int filter = 0; filter < router_config.num_filters; filter++) {
+        while (!fw_queue_empty(&fw_filters[filter])) {
+            net_buff_desc_t buffer;
+            int err = fw_dequeue(&fw_filters[filter], &buffer);
+            assert(!err);
+
+            uintptr_t pkt_vaddr = data_vaddr + buffer.io_or_offset;
+            ipv4_packet_t *ip_pkt = (ipv4_packet_t *)(pkt_vaddr);
+
+            /*
+             * Decrement the TTL field. If it reaches 0 protocol is
+             * that we drop the packet in this router.
+             *
+             * NOTE: We drop non-IPv4 packets. This case should be
+             * handled by the protocol virtualiser.
+             */
+            if (ip_pkt->type != HTONS(ETH_TYPE_IP) || ip_pkt->ttl <= 1) {
+                err = fw_enqueue(&rx_free, &buffer);
+                assert(!err);
+                returned = true;
+                continue;
+            }
+
+            ip_pkt->ttl -= 1;
+
+            if (FW_DEBUG_OUTPUT) {
+                sddf_printf("%sRouter received packet for ip %s with buffer number %lu\n",
+                    fw_frmt_str[router_config.webserver.interface],
+                    ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf0),
+                            buffer.io_or_offset/NET_BUFFER_SIZE);
+            }
+
+            /* Find the next hop address. */
+            uint32_t next_hop;
+            fw_routing_interfaces_t interface;
+            fw_routing_err_t fw_err = fw_routing_find_route(routing_table,
+                                                            ip_pkt->dst_ip,
+                                                            &next_hop,
+                                                            &interface,
+                                                            0);
+            assert(fw_err == ROUTING_ERR_OKAY);
+
+            if (FW_DEBUG_OUTPUT && interface != ROUTING_OUT_NONE) {
+                sddf_printf("%sRouter converted ip %s to next hop ip %s out interface %u\n",
+                    fw_frmt_str[router_config.webserver.interface],
+                    ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf0),
+                    ipaddr_to_string(next_hop, ip_addr_buf1), interface);
+            }
+
+            /* No route, drop packet  */
+            if (interface == ROUTING_OUT_NONE ||
+                (router_config.interface == FW_EXTERNAL_INTERFACE_ID &&
+                interface == ROUTING_OUT_SELF)) {
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sRouter found no route for ip %s, dropping packet\n",
+                        ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf0),
+                        fw_frmt_str[router_config.webserver.interface]);
+                }
+
+                err = fw_enqueue(&rx_free, &buffer);
+                assert(!err);
+                returned = true;
+                continue;
+            } 
+            
+            /* Packet destined for webserver */
+            if (router_config.interface == FW_INTERNAL_INTERFACE_ID &&
+                interface == ROUTING_OUT_SELF) {
+                tcphdr_t *tcp_pkt = (tcphdr_t *)(pkt_vaddr +
+                                        transport_layer_offset(ip_pkt));
+
+                /* Webserver only accepts TCP traffic on webserver port */
+                if (ip_pkt->protocol != WEBSERVER_PROTOCOL ||
+                    tcp_pkt->dst_port != HTONS(WEBSERVER_PORT)) {
+                    err = fw_enqueue(&rx_free, &buffer);
+                    assert(!err);
+                    returned = true;
+                    continue;
+                }
+
+                /* Forward packet to the webserver */
+                err = fw_enqueue(&webserver, &buffer);
+                assert(!err);
+                tx_webserver = true;
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sRouter transmitted packet to webserver\n",
+                    fw_frmt_str[router_config.webserver.interface]);
+                }
+
+                continue;
+
+            }
+
+            fw_arp_entry_t *arp = fw_arp_table_find_entry(&arp_table, next_hop);
+            /* destination unreachable or no space to store packet or send ARP request, drop packet */
+            if ((arp != NULL && arp->state == ARP_STATE_UNREACHABLE) ||
+                (pkt_waiting_full(&pkt_waiting_queue) &&
+                (arp == NULL || arp->state == ARP_STATE_PENDING)) ||
+                (arp == NULL && fw_queue_full(&arp_req_queue))) {
+
+                if (arp != NULL && arp->state == ARP_STATE_UNREACHABLE) {
+                    int icmp_err = enqueue_icmp_unreachable(buffer);
+                    if (icmp_err) {
+                        sddf_dprintf("%sROUTING LOG: Could not enqueue ICMP unreachable!\n",
+                            fw_frmt_str[router_config.webserver.interface]);
+                    }
+                } else {
+                    sddf_dprintf("%sROUTING LOG: Waiting packet or ARP request queue full, dropping packet!\n",
+                        fw_frmt_str[router_config.webserver.interface]);
+                }
+
+                err = fw_enqueue(&rx_free, &buffer);
+                assert(!err);
+                returned = true;
+                continue;
+            }
+            
+            /* no entry in ARP table or request still pending, store packet
+            and send ARP request or await ARP response */
+            if (arp == NULL || arp->state == ARP_STATE_PENDING) {
+                pkt_waiting_node_t *root = pkt_waiting_find_node(&pkt_waiting_queue,
+                                                                 next_hop);
+                if (root) {
+                    /* ARP request already enqueued, add node as child. */
+                    fw_err = pkt_waiting_push_child(&pkt_waiting_queue,
+                                                    root,
+                                                    buffer);
+                    assert(fw_err == ROUTING_ERR_OKAY);
+                } else {
+                    /* Generate ARP request and enqueue packet. */
+                    fw_arp_request_t request = {next_hop, {0}, ARP_STATE_INVALID};
+                    err = fw_enqueue(&arp_req_queue, &request);
+                    assert(!err);
+                    fw_err = pkt_waiting_push(&pkt_waiting_queue,
+                                                next_hop,
+                                                buffer);
+                    assert(fw_err == ROUTING_ERR_OKAY);
+                    notify_arp = true;
+                }
+
+                continue;
+            }
+
+            /* valid arp entry found, transmit packet */
+            transmit_packet(buffer, arp->mac_addr);
+        }
+    }
+}
+
+void init(void)
+{
+    serial_queue_init(&serial_tx_queue_handle,
+                      serial_config.tx.queue.vaddr,
+                      serial_config.tx.data.size,
+                      serial_config.tx.data.vaddr);
+    serial_putchar_init(serial_config.tx.id, &serial_tx_queue_handle);
+
+    /* Set up firewall filter queues */
+    for (int i = 0; i < router_config.num_filters; i++) {
+        fw_queue_init(&fw_filters[i], router_config.filters[i].queue.vaddr,
+            sizeof(net_buff_desc_t), router_config.filters[i].capacity);
+    }
+
+    /* Set up virt rx firewall queue */
+    fw_queue_init(&rx_free, router_config.rx_free.queue.vaddr,
+        sizeof(net_buff_desc_t), router_config.rx_free.capacity);
+
+    /* Set up virt tx firewall queue */
+    fw_queue_init(&tx_active, router_config.tx_active.queue.vaddr,
+        sizeof(net_buff_desc_t), router_config.tx_active.capacity);
+
+    data_vaddr = (uintptr_t)router_config.data.vaddr;
+
+    /* Initialise arp queues */
+    fw_queue_init(&arp_req_queue, router_config.arp_queue.request.vaddr,
+        sizeof(fw_arp_request_t), router_config.arp_queue.capacity);
+    fw_queue_init(&arp_resp_queue, router_config.arp_queue.response.vaddr,
+        sizeof(fw_arp_request_t), router_config.arp_queue.capacity);
+    fw_arp_table_init(&arp_table, (fw_arp_entry_t *)router_config.arp_cache.vaddr,
+        router_config.arp_cache_capacity);
+
+    fw_queue_init(&icmp_queue, router_config.icmp_module.queue.vaddr, sizeof(icmp_req_t),
+                    router_config.icmp_module.capacity);
+
+    /* Initialise routing table */
+    fw_routing_table_init(&routing_table,
+                          router_config.webserver.routing_table.vaddr,
+                          router_config.webserver.routing_table_capacity,
+                          router_config.out_ip,
+                          router_config.out_subnet);
+
+    /* Set up router --> webserver queue. */
+    if (router_config.interface == FW_INTERNAL_INTERFACE_ID) {
+        fw_queue_init(&webserver, router_config.rx_active.queue.vaddr,
+            sizeof(net_buff_desc_t), router_config.rx_active.capacity);
+        
+        /* Add an entry for the webserver */
+        fw_routing_table_add_route(routing_table,
+                                   ROUTING_OUT_SELF,
+                                   router_config.ip,
+                                   32,
+                                   router_config.ip);
+    }
+
+    assert(router_config.packet_queue.vaddr != 0);
+    /* Initialise the packet waiting queue from mapped in memory */
+    pkt_waiting_init(&pkt_waiting_queue,
+                     (void *) router_config.packet_queue.vaddr,
+                     router_config.rx_free.capacity);
+}
+
+seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
+{
+    switch (microkit_msginfo_get_label(msginfo)) {
+    case FW_ADD_ROUTE: {
+        uint32_t ip = seL4_GetMR(ROUTER_ARG_IP);
+        uint8_t subnet = seL4_GetMR(ROUTER_ARG_SUBNET);
+        uint32_t next_hop = seL4_GetMR(ROUTER_ARG_NEXT_HOP);
+        // @kwinter: Limiting this to just external routes out of the NIC
+        // for now.
+        fw_routing_err_t err = fw_routing_table_add_route(routing_table,
+                                                          ROUTING_OUT_EXTERNAL,
+                                                          ip,
+                                                          subnet,
+                                                          next_hop);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sRouter add route. (ip %s, mask %u, next hop %s): %s\n",
+                fw_frmt_str[router_config.webserver.interface],
+                ipaddr_to_string(ip, ip_addr_buf0), subnet,
+                ipaddr_to_string(next_hop, ip_addr_buf1),
+                        fw_routing_err_str[err]);
+        }
+        seL4_SetMR(ROUTER_RET_ERR, err);
+        return microkit_msginfo_new(0, 1);
+    }
+    case FW_DEL_ROUTE: {
+        uint16_t route_id = seL4_GetMR(ROUTER_ARG_ROUTE_ID);
+        fw_routing_err_t err = fw_routing_table_remove_route(routing_table, route_id);
+
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sRouter delete route %u: %s\n",
+                fw_frmt_str[router_config.webserver.interface],
+                route_id, fw_routing_err_str[err]);
+        }
+
+        seL4_SetMR(ROUTER_RET_ERR, err);
+        return microkit_msginfo_new(0, 1);
+    }
+    default:
+        sddf_printf("%sROUTING LOG: unknown request %lu on channel %u\n",
+            fw_frmt_str[router_config.webserver.interface],
+            microkit_msginfo_get_label(msginfo), ch);
+        break;
+    }
+
+    return microkit_msginfo_new(0, 0);
+}
+
+void notified(microkit_channel ch)
+{
+    if (ch == router_config.arp_queue.ch) {
+        /*
+         * This is the channel between the ARP component and the
+         * routing component
+         */
+        process_arp_waiting();
+    } else {
+        /* Router has been notified by a filter */
+        route();
+    }
+
+    if (notify_icmp) {
+        notify_icmp = false;
+        microkit_notify(router_config.icmp_module.ch);
+    }
+
+    if (notify_arp) {
+        notify_arp = false;
+        microkit_notify(router_config.arp_queue.ch);
+    }
+
+    if (router_config.interface == FW_INTERNAL_INTERFACE_ID && tx_webserver) {
+        tx_webserver = false;
+        microkit_notify(router_config.rx_active.ch);
+    }
+
+    if (returned) {
+        returned = false;
+        microkit_deferred_notify(router_config.rx_free.ch);
+    }
+
+    if (tx_net) {
+        tx_net = false;
+        microkit_notify(router_config.tx_active.ch);
+    }
+}
+
+/* Extract the entry size of variable length data structures to calculate the
+precise sdfgen memory region size needed. */
+const __attribute__ ((unused)) size_t fw_buffer_queue_entry_size = sizeof(net_buff_desc_t);
+const __attribute__ ((unused)) size_t fw_arp_queue_entry_size = sizeof(fw_arp_request_t);
+const __attribute__ ((unused)) size_t fw_icmp_queue_entry_size = sizeof(icmp_req_t);
+const __attribute__ ((unused)) size_t fw_arp_entry_size = sizeof(fw_arp_entry_t);
+const __attribute__ ((unused)) size_t fw_arp_pkt_node_size = sizeof(pkt_waiting_node_t);
+const __attribute__ ((unused)) size_t fw_routing_entry_size = sizeof(fw_routing_entry_t);
+const __attribute__ ((unused)) size_t fw_rule_size = sizeof(fw_rule_t);
+const __attribute__ ((unused)) size_t fw_instance_size = sizeof(fw_instance_t);

--- a/examples/firewall/sdfgen_helper.py
+++ b/examples/firewall/sdfgen_helper.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+import re
+import subprocess
+import shutil
+from os import path
+
+### Explanation
+# Since this script generates the python classes that will be used by the metaprogram, it will
+# typically be run before the build process and whenever a configuration struct is changed. It will
+# generate a python struct class and serialisable class for each struct definition in each C header
+# that it is passed. These classes make the process of creating a meta program much simpler and less
+# error prone. Run the script on all the config headers used by your system (that are not serialised
+# by the sdfgen tool) before creating your meta program and you can import the generated classes
+# into your meta program and use them to create data files to be copied into your elfs.
+
+# This script also contains a couple of other useful functions for creating copies of elf files and
+# updating elf sections with the data files serialised by the generated classes.
+
+### Assumptions
+# If macros or types are found in config files that are not defined, the script will output them
+# upon termination and will not create the python classes. If the unknown type is a c type, simply
+# add it to the c_type_to_p_class dictionary. If macros are unknown, their values can be passed to
+# the script as arguments. If a C type is unknown and defined in another header, either include this
+# header in the files passed to the script, or temporarily add the definition to one of the config
+# files passed to generate the the python classes, then remove before building your system.
+# 
+# The script assumes that config headers are passed in order of dependencies, so be sure to pass
+# files containing definitions that are used in other files first.
+#
+# The script assumes that all comments are across entire lines.
+# 
+# Currently the script only supports simple single value macro substitutions and will fail to
+# recognise more complex expressions.
+#
+# This script assumes that a struct field with the prefix "num_" refers to the length of another
+# field if the substring following "num_" is equal to the name of the other field. If this is true,
+# the field prefixed with "num_" will not be treated as a separate field to the matching field, and
+# instead will be set to the length of the matching field.
+
+# Creates a new elf with elf_number as prefix. Adds ".elf" to elf strings
+def copy_elf(source_elf: str, new_elf: str, elf_number = None):
+    source_elf += ".elf"
+    if elf_number != None:
+        new_elf += str(elf_number)
+    new_elf += ".elf"
+    assert path.isfile(source_elf)
+    return shutil.copyfile(source_elf, new_elf)
+
+# Copiers data region data_name into section_name of elf_name
+def update_elf_section(obj_copy: str, elf_name: str, section_name: str, data_name: str):
+    assert path.isfile(elf_name)
+    assert path.isfile(data_name)
+    assert subprocess.run([obj_copy, "--update-section", "." + section_name + "=" + data_name, elf_name]).returncode == 0
+
+c_name_regex = r"[a-zA-Z_][a-zA-Z0-9_]{0,63}"
+# Currently we only support digits and macros for array sizes
+c_value_regex = c_name_regex + r"|0b[01]+|0x[a-fA-F0-9]+|[0-9]+"
+c_type_to_p_class = {
+    "bool": "c_bool",
+    "char": "c_char",
+    "unsigned char": "c_ubyte",
+    "short": "c_short",
+    "unsigned short": "c_ushort",
+    "int": "c_int",
+    "unsigned int": "c_uint",
+    "unsigned": "c_uint",
+    "long": "c_long",
+    "unsigned long": "c_ulong",
+    "long long": "c_longlong",
+    "float": "c_float",
+    "double": "c_double",
+    "long double": "c_longdouble",
+    "uint8_t": "c_uint8",
+    "uint16_t": "c_uint16",
+    "uint32_t": "c_uint32",
+    "uint64_t": "c_uint64",
+    "size_t": "c_size_t",
+    "ssize_t": "c_ssize_t",
+    "uintptr_t": "c_uint64",
+}
+p_pointer_class = "c_uint64"
+c_operators = ["+", "-", "*", "-"]
+p_class_to_p_type = {
+    "c_bool": "bool",
+    "c_char": "str",
+    "c_ubyte": "bytes",
+    "c_short": "int",
+    "c_ushort": "int",
+    "c_int": "int",
+    "c_uint": "int",
+    "c_uint": "int",
+    "c_long": "int",
+    "c_ulong": "int",
+    "c_longlong": "int",
+    "c_uint8": "int",
+    "c_uint16": "int",
+    "c_uint32": "int",
+    "c_uint64": "int",
+    "c_size_t": "int",
+    "c_ssize_t": "int",
+    "c_float": "float",
+    "c_double": "float",
+    "c_longdouble": "float"
+}
+
+# Macro and type classes
+class Macro():
+    # Store all known config macros
+    all_macros = dict()
+
+    # Store all encountered undefined macros
+    unknown_macros = dict()
+
+    def __init__(self, c_name, value):
+        if c_name in Macro.all_macros:
+            print(f"Duplicate definition found for macro {c_name}: {Macro.all_macros[c_name]}")
+            sys.exit()
+        self.c_name = c_name
+        self.p_name = cNameToPName(c_name)
+        self.value = value
+        Macro.all_macros[c_name] = self
+
+class Struct():
+    # Store all config structs
+    all_structs = dict()
+
+    # Store all encountered undefined types
+    unknown_types = dict()
+
+    # Input c_name without "_t" suffix
+    def __init__(self, c_name):
+        if c_name  + "_t" in Struct.all_structs:
+            print(f"Duplicate definition found for type {c_name}: {Struct.all_structs[c_name]}")
+            sys.exit()
+        self.p_name = cNameToPName(c_name) + "Struct"
+        self.c_name = c_name + "_t"
+        self.fields = dict()
+        Struct.all_structs[self.c_name] = self
+    
+    def addField(self, field):
+        if field.c_name in self.fields:
+            print(f"Duplicate field {field.c_name} for type {self.c_name}")
+            sys.exit()
+        self.fields[field.c_name] = field
+
+class Field():
+    def __init__(self, struct, c_name, c_type, c_size):
+        self.c_name = c_name
+        self.c_type = c_type
+        self.c_size = c_size
+
+        # Extract python class and size and numeric size
+        Field.cTypeToPClass(self, struct, c_type)
+        Field.cSizeToPandNSize(self, struct, c_size)
+
+        # Add field to parent struct
+        struct.addField(self)
+
+    def cTypeToPClass(self, struct, c_type):
+        if c_type[-1] == "*":
+            self.p_class = p_pointer_class
+        elif c_type in c_type_to_p_class:
+            self.p_class = c_type_to_p_class[c_type]
+        elif c_type in Struct.all_structs:
+            self.p_class = Struct.all_structs[c_type].p_name
+        elif c_type not in Struct.unknown_types:
+            Struct.unknown_types[c_type] = [(struct, self)]
+            self.p_class = None
+        else:
+            Struct.unknown_types[c_type].append((struct, self))
+            self.p_class = None
+    
+    def cSizeToPandNSize(self, struct, c_size):
+        self.p_size = []
+        self.n_size = []
+        eval_size = True
+        for word in c_size:
+            # Word is a digit or an operator
+            if re.match(r"^[0-9]+$", word) or word in c_operators:
+                self.p_size.append(word)
+                self.n_size.append(word)
+            # Word is a macro
+            elif word in Macro.all_macros:
+                self.p_size.append(Macro.all_macros[word].p_name)
+                self.n_size.append(Macro.all_macros[word].value)
+            elif word not in Macro.unknown_macros:
+                Macro.unknown_macros[word] = [(struct, self)]
+                self.p_size.append(f"unknown")
+                self.n_size.append(f"unknown")
+                eval_size = False
+            else:
+                Macro.unknown_macros[word].append((struct, self))
+                self.p_size.append(f"unknown")
+                self.n_size.append(f"unknown")
+                eval_size = False
+        if len(c_size) and eval_size:
+            self.e_size = eval("".join(self.n_size))
+        else:
+            self.e_size = ""
+        return
+
+def cNameToPName(c_name):
+    p_name = ""
+    for word in c_name.lower().split("_"):
+        p_name += word.capitalize()
+    
+    return p_name
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    
+    # Accept values for unknown Macros
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--configs", required=True)
+    parser.add_argument("--macros", required=False)
+    args = parser.parse_args()
+    
+    p_classes_out = args.output
+    
+    # Store argument passed macros
+    if args.macros:
+        for macro_def in args.macros.split(" "):
+            macro_val = macro_def.split("=")
+            Macro(macro_val[0], macro_val[1])
+    
+    # Extract struct files
+    c_headers = args.configs.split(" ")
+
+    # Process all config headers
+    for file in c_headers:
+        with open(file, "r") as input:
+            for line in input:
+
+                # Match on macros
+                match = re.match(r"#define[ \t]+(" + c_name_regex + ")[ \t]+(" + c_value_regex + r")", line)
+                if match:
+                    c_name = match.group(1)
+                    value = match.group(2)
+                    macro = Macro(c_name, value)
+                    continue;
+                    
+                # Match on struct typedef
+                match = re.match(r"typedef[ \t]+struct[ \t]+(" + c_name_regex + ")[ \t]*{", line)
+                if not match:
+                    continue
+                c_name = match.group(1)
+                struct = Struct(c_name)
+
+                # Find struct fields
+                line = next(input)
+                # Line either does not have struct end } or contains definition
+                while not re.match(r"[^;]*}.*", line):
+
+                    # Ignore comments and lines without definitions
+                    if re.match(r"[ \t]*[/*]|^[^;]*$", line):
+                        line = next(input)
+                        continue
+
+                    # Match on struct fields
+                    match = re.match(r"[ \t]*(" + c_name_regex + r")(?:[ \t]+|[ \t]*([*]+)[ \t]*)(" + c_name_regex + r")[ \t]*(\[([^\]]*)?])?[ \t]*;", line)
+                    c_name = match.group(3)
+                    c_type = match.group(1)
+                    c_size_literal = match.group(5)
+
+                    # Pointer type or field is array with empty size
+                    if match.group(2) or (match.group(4) and not c_size_literal):
+                        c_type += match.group(2)
+
+                    # Process array size
+                    if c_size_literal:
+                        c_size = [c_size_literal]
+                    else:
+                        c_size = []
+
+                    # Extract operators
+                    for op in c_operators:
+                        next_c_size = []
+                        for word in c_size:
+
+                            # Ignore single characters of operators
+                            if len(word) == 1:
+                                next_c_size.append(word)
+                                continue
+
+                            # Split string on each operator
+                            args = word.split(op)
+                            if len(args) == 1:
+                                next_c_size.append(word)
+                            else:
+                                for arg in args[:-1]:
+                                    next_c_size.append(arg.strip())
+                                    next_c_size.append(op)
+                                next_c_size.append(args[-1].strip())
+                        
+                        c_size = next_c_size
+                    
+                    field = Field(struct, c_name, c_type, c_size)
+
+                    # This was the last field
+                    match = re.match(".*}.*", line)
+                    if match:
+                        break
+                    else:
+                        line = next(input)
+
+    with open(p_classes_out, "w") as out:
+
+        # Import modules
+        out.write("from typing import List\n")
+        out.write("from ctypes import *\n\n")
+
+        if Macro.unknown_macros or Struct.unknown_types:
+            out.write("unknown = None\n\n")
+
+        if Macro.unknown_macros:
+            out.write("# Missing macros used in struct fields:\n")
+            for macro in Macro.unknown_macros.keys():
+                out.write(f"# {macro}:\n")
+                for struct, field in Macro.unknown_macros[macro]:
+                    out.write(f"# - {struct.c_name}: {field.c_name}\n")
+                out.write("\n")
+            out.write("\n")
+
+        if Struct.unknown_types:
+            out.write("# Missing types used in struct fields:\n")
+            for struct in Struct.unknown_types.keys():
+                out.write(f"# {struct}:\n")
+                for missing_struct, field in Struct.unknown_types[struct]:
+                    out.write(f"# - {missing_struct.c_name}: {field.c_name}\n")
+                out.write("\n")
+            out.write("\n")
+        
+        if Macro.unknown_macros or Struct.unknown_types:
+            sys.exit()
+
+        out.write("# Macros:\n")
+        for macro in Macro.all_macros.values():
+            out.write(f"# {macro.c_name}\n")
+            out.write(f"{macro.p_name} = {macro.value}\n")
+        out.write("\n")
+
+        # Create struct classes
+        out.write("# Struct Classes\n")
+        for struct in Struct.all_structs.values():
+            out.write(f"# {struct.c_name}\nclass {struct.p_name}(LittleEndianStructure):\n")
+            next_line = f"    _fields_ = ["
+            for i, field in zip(range(len(struct.fields.values())), struct.fields.values()):
+
+                # Handle array fields
+                next_line += f"(\"{field.c_name}\", {field.p_class}"
+                comment_line = " " * 17 + f"# C type: {field.c_type}"
+                if len(field.n_size) == 1:
+                    next_line += f" * {field.n_size[0]}"
+                    comment_line += f", C array size: {field.c_size[0]} ({field.p_size[0]})"
+                # Multi argument size
+                elif len(field.n_size) > 1:
+                    next_line += " * ("
+                    comment_line += ", C array size: "
+                    size_count = 0
+                    for raw, py, c in zip(field.n_size, field.p_size, field.c_size):
+                        size_count += 1
+                        plain_text = re.match(r"^[0-9]+$", py) or py in c_operators
+                        if size_count < len(field.n_size):
+                            next_line += f"{raw} "
+                            if plain_text:
+                                comment_line += f"{c} "
+                            else:
+                                comment_line += f"{c} ({py}) "
+                        else:
+                            next_line += f"{raw})"
+                            if plain_text:
+                                comment_line += f"{c}"
+                            else:
+                                comment_line += f"{c} ({py})"
+                if i < len(struct.fields) - 1:
+                    next_line += f"),\n"
+                else:
+                    next_line += f")]\n\n"
+                comment_line += "\n"
+                out.write(comment_line)
+                out.write(next_line)
+                next_line =  " " * 17
+
+        out.write("\n")
+
+        # Create serializable structs
+        out.write("class Serializable():\n    def serialise(self):\n        return bytes(self.to_struct())\n\n")
+        for struct in Struct.all_structs.values():
+
+            # Create arguments
+            out.write(f"class {struct.p_name[:-6]}(Serializable):\n    def __init__(self")
+            for field in struct.fields.values():
+                if field.c_name[:4] == "num_" and field.c_name[4:] in struct.fields:
+                    continue
+                list_start = ""
+                list_end = ""
+                if len(field.n_size):
+                    list_start = "List["
+                    list_end = "]"
+                if field.c_type in Struct.all_structs:
+                    out.write(f", {field.c_name}: {list_start}{field.p_class[:-6]}{list_end}")
+                else:
+                    out.write(f", {field.c_name}: {list_start}{p_class_to_p_type[field.p_class]}{list_end}")
+            out.write("):\n")
+
+            # Initialise field objects
+            for field in struct.fields.values():
+                if field.c_name[:4] == "num_" and field.c_name[4:] in struct.fields:
+                    continue
+                out.write(" " * 8 + f"self.{field.c_name} = {field.c_name}\n")
+            out.write(" " * 8 + f"self.section_name = \"{struct.c_name[:-2]}\"\n")
+            out.write("\n")
+
+            # Define serializable class to struct function
+            out.write(" " * 4 + f"def to_struct(self) -> {struct.p_name}:\n")
+            for field in struct.fields.values():
+                out.write(" " * 8)
+                if len(field.n_size) and field.c_type not in Struct.all_structs:
+                    out.write(f"{field.c_name}_arg = self.{field.c_name} + [{field.p_class}()] * ({field.e_size} - len(self.{field.c_name}))")
+                elif len(field.n_size) and field.c_type in Struct.all_structs:
+                    out.write(f"{field.c_name}_arg = [x.to_struct() for x in self.{field.c_name}] + (({field.e_size} - len(self.{field.c_name})) * [{field.p_class}()])")
+                elif field.c_type in Struct.all_structs:
+                    out.write(f"{field.c_name}_arg = {field.p_class}() if self.{field.c_name} is None else self.{field.c_name}.to_struct()")
+                elif field.c_name[:4] == "num_" and field.c_name[4:] in struct.fields:
+                    out.write(f"{field.c_name}_arg = len(self.{field.c_name[4:]})")
+                else:
+                    out.write(f"{field.c_name}_arg = {field.p_class}() if self.{field.c_name} is None else self.{field.c_name}")
+                out.write("\n")
+
+            # Create to_struct.serialise arguments
+            out.write(" " * 8 + f"return {struct.p_name}(")
+            for i, field in zip(range(len(struct.fields.values())), struct.fields.values()):
+                if field.n_size:
+                    out.write(f"({field.p_class} * {field.e_size})(*{field.c_name}_arg)")
+                else:
+                    out.write(f"{field.c_name}_arg")
+                if i < len(struct.fields) - 1:
+                    out.write(", \n" + " " * (16 + len(struct.p_name)))
+            out.write(")\n\n")

--- a/examples/firewall/ui_server.py
+++ b/examples/firewall/ui_server.py
@@ -1,0 +1,995 @@
+# Copyright 2025, UNSW
+# SPDX-License-Identifier: BSD-2-Clause
+
+from microdot import Microdot, Response
+import lions_firewall
+
+
+############ Network Constants ############
+
+EthHWAddrLen = 6
+IPAddrLen = 4
+maxIpDigit = 255
+maxPortNum = 65535
+maxSubnetMask = 32
+
+############ System Constants and Errors ############
+
+OSErrOkay = 0
+OSErrInvalidInterface = 1
+OSErrInvalidProtocol = 2
+OSErrInvalidRouteID = 3
+OSErrInvalidRuleID = 4
+OSErrInvalidRouteArgs = 5
+OSErrDuplicate = 6
+OSErrClash = 7
+OSErrInvalidArguments = 8
+OSErrInvalidRouteNum = 9
+OSErrInvalidRuleNum = 10
+OSErrOutOfMemory = 11
+OSErrInternalError = 12
+OSErrInvalidInput = 13
+
+OSErrStrings = [
+    "Ok.",
+    "Invalid interface ID supplied.",
+    "No matching filter for supplied protocol number.",
+    "No route matching supplied route ID.",
+    "No rule matching supplied rule ID.",
+    "Invalid arguments supplied to add route.",
+    "Route or rule supplied already exists.",
+    "Route or rule supplied clashes with an existing route or rule.",
+    "Too many or too few arguments supplied.",
+    "Route number supplied is greater than the number of routes.",
+    "Rule number supplied is greater than the number of rules.",
+    "Internal data structures are already at capacity.",
+    "Unknown internal error.",
+    "Input supplied does not match the format of the field."
+]
+
+UnknownErrStr = "Unexpected unknown error."
+
+numInterfaces = 2
+
+interfaceStringsRouters = [
+    "internal",
+    "external",
+]
+
+interfaceStringsFilters = [
+    "external",
+    "internal"
+]
+
+interfaceStringsCap = [
+    "External",
+    "Internal"
+]
+
+protocolNums = {
+    "icmp": 0x01,
+    "tcp": 0x06,
+    "udp": 0x11
+}
+
+actionNums = {
+    1: "Allow",
+    2: "Drop",
+    3: "Connect"
+}
+
+############ Helper Functions ############
+
+def ipToInt(ipString):
+    ipSplit = ipString.split(".")
+    if not len(ipSplit) == 4:
+        print(f"UI SERVER|ERR: Incorrect format of supplied IP {ipString}.")
+        raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+    ipList = []
+    for strDigit in ipSplit:
+        try:
+            digit = int(strDigit)
+            ipList.append(digit)
+        except:
+            print(f"UI SERVER|ERR: Supplied IP digit {strDigit} is not a valid integer.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+    for digit in ipList:
+        if digit < 0 or digit > maxIpDigit:
+            print(f"UI SERVER|ERR: Supplied IP digit {digit} is negative or too large.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+    ipInt = 0
+    for i in range(4):
+        ipInt += (ipList[i] << (8 * i))
+    return ipInt
+
+def intToIp(ipInt):
+    ipString = ""
+    prevMaskSum = 0
+    for i in range(4):
+        mask = pow(2, 8 * (1 + i)) - 1 - prevMaskSum
+        if i:
+            ipString = ipString + "."
+        ipString = ipString + str((ipInt & mask) >> (8 * i))
+        prevMaskSum += mask
+    return ipString
+
+def tupleToMac(macList):
+    macList = list(macList)
+    if len(macList) != EthHWAddrLen:
+        print(f"UI SERVER|ERR: System supplied MAC address {macList} has too many digits.")
+        raise OSError(OSErrInternalError, OSErrStrings[OSErrInternalError])
+
+    # Switch big to little endian
+    hexList = list(map(lambda digit: hex(digit)[2:], macList))
+
+    # Ensure digits are in the right format
+    for i in range(len(hexList)):
+        if len(hexList[i]) > 2:
+            print(f"UI SERVER|ERR: System supplied MAC address {macList} contains a digit that is too large.")
+            raise OSError(OSErrInternalError, OSErrStrings[OSErrInternalError])
+        elif len(hexList[i]) < 2:
+            hexList[i] = "0" + hexList[i]
+
+    mac = ":".join(hexList)
+    return mac
+    
+def interfaceStringToInt(componentType, interfaceStr):
+  if componentType == "router":
+      for i in range(numInterfaces):
+        if interfaceStr == interfaceStringsRouters[i]:
+            return i
+  elif componentType == "filter":
+    for i in range(numInterfaces):
+        if interfaceStr == interfaceStringsFilters[i]:
+            return i
+
+    print(f"UI SERVER|ERR: Supplied interface string {interfaceStr} does not match existing interfaces.")
+    raise OSError(OSErrInvalidInterface, OSErrStrings[OSErrInvalidInterface])
+
+
+############ Route APIs ############
+
+app = Microdot()
+
+###### Interface methods ######
+
+# Get the number of interfaces
+@app.route('/api/interfaces/count', methods=['GET'])
+def interfaceCount(request):
+    return {"count": numInterfaces}
+
+
+# Get interface details
+@app.route('/api/interfaces/<int:interfaceInt>', methods=['GET'])
+def interfaceDetails(request, interfaceInt):
+    try:
+        if interfaceInt < 0 or interfaceInt >= numInterfaces:
+            print(f"UI SERVER|ERR: Supplied interface integer {interfaceInt} does not match existing interfaces.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+        return {
+                "interface": interfaceStringsCap[interfaceInt],
+                "mac": tupleToMac(lions_firewall.interface_mac_get(interfaceInt)),
+                "ip": intToIp(lions_firewall.interface_ip_get(interfaceInt)),
+            }
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: interfaceDetails: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: interfaceDetails: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
+
+###### Routing config methods ######
+
+# Get routes for an interface
+@app.route('/api/routes/<string:interfaceStr>', methods=['GET'])
+def getRoutes(request, interfaceStr):
+    try:
+        interface = interfaceStringToInt("router", interfaceStr)
+        routes = []
+        route_count = lions_firewall.route_count(interface)
+        for i in range(route_count):
+            route = lions_firewall.route_get_nth(interface, i)
+            routes.append({
+                "id": route[0],
+                "ip": intToIp(route[1]),
+                "subnet": route[2],
+                "next_hop": intToIp(route[3])
+            })
+        return {"routes": routes}
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: getRoutes: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: getRoutes: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
+# Delete a route from an interface
+@app.route('/api/routes/<int:routeId>/<string:interfaceStr>', methods=['DELETE'])
+def deleteRoute(request, routeId, interfaceStr):
+    try:
+        interface = interfaceStringToInt("router", interfaceStr)
+        lions_firewall.route_delete(interface, routeId)
+        return {"status": "ok"}
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: deleteRoute: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: deleteRoute: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
+
+# Add a route to an interface
+@app.route('/api/routes', methods=['POST'])
+def addRoute(request):
+    try:
+        newRoute = request.json
+        interfaceInt = newRoute.get("interface")
+        if interfaceInt < 0 or interfaceInt >= numInterfaces:
+            print(f"UI SERVER|ERR: Supplied interface integer {interfaceInt} does not match existing interfaces.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+        subnet = newRoute.get("subnet")
+        if subnet < 0 or subnet > maxSubnetMask:
+            print(f"UI SERVER|ERR: Supplied subnet mask {subnet} is invalid.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+        
+        # No IP needed for subnet == 0: route matches all IP
+        if subnet == 0:
+            ip = 0
+        else:
+            ip = ipToInt(newRoute.get("ip"))
+
+        nextHop = newRoute.get("next_hop")
+        if len(nextHop) == 0 or nextHop == "0":
+          nextHop = 0
+        else:
+          nextHop = ipToInt(nextHop)
+
+        lions_firewall.route_add(interfaceInt, ip, subnet, nextHop)
+        newRouteOut = {"interface": interfaceInt, "ip": ip, "next_hop": nextHop}
+
+        return {"status": "ok", "route": newRouteOut}, 201
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: addRoute: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: addRoute: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
+
+###### Filter rule methods ######
+
+# Get rules and default rules for an interface filter
+@app.route('/api/rules/<string:protocolStr>/<string:interfaceStr>', methods=['GET'])
+def getRules(request, protocolStr, interfaceStr):
+    try:
+        interface = interfaceStringToInt("filter", interfaceStr)
+
+        if protocolStr not in protocolNums.keys():
+            print(f"UI SERVER|ERR: Supplied protocol string {protocolStr} does not match existing filters.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+        protocol = protocolNums[protocolStr]
+
+        defaultAction = lions_firewall.filter_get_default_action(interface, protocol)
+        rules = []
+        for i in range(lions_firewall.rule_count(interface, protocol)):
+            rule = lions_firewall.rule_get_nth(interface, protocol, i)
+            rules.append({
+                "id": rule[0],
+                "src_ip": intToIp(rule[1]),
+                "src_port": rule[2],
+                "src_port_any": rule[3],
+                "dest_ip": intToIp(rule[4]),
+                "dest_port": rule[5],
+                "dest_port_any": rule[6],
+                "src_subnet": rule[7],
+                "dest_subnet": rule[8],
+                "action": actionNums[rule[9]]
+            })
+        return {"default_action": defaultAction, "rules": rules}
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: getRules: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: getRules: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
+
+# Delete a rule for an interface filter
+@app.route('/api/rules/<string:protocolStr>/<int:ruleId>/<string:interfaceStr>', methods=['DELETE'])
+def deleteRule(request, protocolStr, ruleId, interfaceStr):
+    try:
+        interface = interfaceStringToInt("filter", interfaceStr)
+
+        if protocolStr not in protocolNums.keys():
+            print(f"UI SERVER|ERR: Supplied protocol string {protocolStr} does not match existing filters.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+        protocol = protocolNums[protocolStr]
+
+        lions_firewall.rule_delete(interface, ruleId, protocol)
+        return {"status": "ok"}
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: deleteRule: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: deleteRule: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
+
+# Add a new default action for an interface filter
+@app.route('/api/rules/<string:protocolStr>/default/<int:action>/<string:interfaceStr>', methods=['POST'])
+def setDefaultAction(request, protocolStr, action, interfaceStr):
+    try:
+        interface = interfaceStringToInt("filter", interfaceStr)
+
+        if protocolStr not in protocolNums.keys():
+            print(f"UI SERVER|ERR: Supplied protocol string {protocolStr} does not match existing filters.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+        protocol = protocolNums[protocolStr]
+
+        lions_firewall.filter_set_default_action(interface, protocol, action)
+        return {"status": "ok"}, 201
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: setDefaultAction: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: setDefaultAction: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
+
+# Add a new rule for an interface filter
+@app.route('/api/rules/<string:protocolStr>', methods=['POST'])
+def addRule(request, protocolStr):
+    try:
+        if protocolStr not in protocolNums.keys():
+            print(f"UI SERVER|ERR: Supplied protocol string {protocolStr} does not match existing filters.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+        protocol = protocolNums[protocolStr]
+
+        newRule = request.json
+        interfaceInt = newRule.get("interface")
+        if interfaceInt < 0 or interfaceInt >= numInterfaces:
+            print(f"UI SERVER|ERR: Supplied interface integer {interfaceInt} does not match existing interfaces.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+        
+        srcSubnet = newRule.get("src_subnet")
+        if srcSubnet < 0 or srcSubnet > maxSubnetMask:
+            print(f"UI SERVER|ERR: Supplied source subnet mask {srcSubnet} is invalid.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+        # No IP needed for subnet == 0: rule matches all IP
+        if srcSubnet == 0:
+            srcIp = 0
+        else:
+            srcIp = ipToInt(newRule.get("src_ip"))
+            
+        destSubnet = newRule.get("dest_subnet")
+        if destSubnet < 0 or destSubnet > maxSubnetMask:
+            print(f"UI SERVER|ERR: Supplied destination subnet mask {destSubnet} is invalid.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+        # No IP needed for subnet == 0: rule matches all IP
+        if destSubnet == 0:
+            destIp = 0
+        else:
+            destIp = ipToInt(newRule.get("dest_ip"))
+
+        action = newRule.get("action")
+        if action not in actionNums.keys():
+            print(f"UI SERVER|ERR: Supplied invalid action {action}.")
+            raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+        srcPort = newRule.get("src_port")
+        if not srcPort:
+            srcPort = 0
+            srcPortAny = True
+        else:
+            srcPort = int(srcPort)
+            srcPortAny = False
+
+        destPort = newRule.get("dest_port")
+        if not destPort:
+            destPort = 0
+            destPortAny = True
+        else:
+            destPort = int(destPort)
+            destPortAny = False
+
+        if protocol == protocolNums["icmp"] or srcPort is None:
+            srcPortAny = True
+        else:            
+            if srcPort < 0 or srcPort > maxPortNum:
+                print(f"UI SERVER|ERR: Supplied invalid source port {srcPort}.")
+                raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+        if protocol == protocolNums["icmp"] or destPort is None:
+            destPortAny = True
+        else:            
+            if destPort < 0 or destPort > maxPortNum:
+                print(f"UI SERVER|ERR: Supplied invalid destination port {destPort}.")
+                raise OSError(OSErrInvalidInput, OSErrStrings[OSErrInvalidInput])
+
+        ruleId = lions_firewall.rule_add(interfaceInt, protocol, srcIp, srcPort, srcPortAny,
+                                         srcSubnet, destIp, destPort, destPortAny, destSubnet, action)
+        return {"status": "ok", "rule": {"id": ruleId}}, 201
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: addRule: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: addRule: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
+
+############ Web UI routes ############
+
+@app.route('/')
+def index(request):
+    html = """
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Firewall Config</title>
+    <link rel="stylesheet" href="/main.css">
+  </head>
+  <body>
+    <h1>Firewall Configuration</h1>
+    <nav>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+    </nav>
+  </body>
+</html>
+"""
+    return Response(body=html, headers={'Content-Type': 'text/html'})
+
+@app.route('/interface')
+def index(request):
+    html = """
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Firewall Config</title>
+    <link rel="stylesheet" href="/main.css">
+  </head>
+  <body>
+    <h1>Firewall Configuration</h1>
+    <nav>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+    </nav>
+    <div id="interfaces-container">
+      <table border="1">
+        <thead>
+          <tr>
+            <th>Interface</th>
+            <th>MAC Address</th>
+            <th>Network IP</th>
+          </tr>
+        </thead>
+        <tbody id="interfaces-body">
+          <tr><td colspan="3">Loading interface data...</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        var tbody = document.getElementById('interfaces-body');
+        tbody.innerHTML = "";
+        fetch('/api/interfaces/count')
+          .then(response => response.json())
+          .then(data => {
+            for (let i = 0; i < data.count; i++) {
+              fetch('/api/interfaces/' + i)
+                .then(response => response.json())
+                .then(info => {
+                  let row = document.createElement('tr');
+                  row.innerHTML = "<td>" + info.interface + "</td>" +
+                                  "<td>" + info.mac + "</td>" +
+                                  "<td>" + info.ip + "</td>";
+                  tbody.appendChild(row);
+                })
+                .catch(err => {
+                  alert("Error" + info.error);
+                  let row = document.createElement('tr');
+                  row.innerHTML = "<td colspan='3'>Error retrieving interface " + i + "</td>";
+                  tbody.appendChild(row);
+                });
+            }
+          })
+          .catch(err => {
+            tbody.innerHTML = "<tr><td colspan='3'>Error retrieving interface count</td></tr>";
+          });
+      });
+    </script>
+  </body>
+</html>
+"""
+    return Response(body=html, headers={'Content-Type': 'text/html'})
+
+@app.route('/routing_config')
+def config(request):
+    html = """
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Routing Config Page</title>
+    <link rel="stylesheet" href="/main.css">
+  </head>
+  <body>
+    <h1>Routing Configuration Page</h1>
+    <nav>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+    </nav>
+
+    <h2>Internal Interface Routing Table</h2>
+    <table border="1">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>IP</th>
+          <th>Subnet</th>
+          <th>Next Hop</th>
+        </tr>
+      </thead>
+      <tbody id="internal-routes-body">
+        <tr>
+          <td colspan="5">Loading routes...</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>External Interface Routing Table</h2>
+    <table border="1">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>IP</th>
+          <th>Subnet</th>
+          <th>Next Hop</th>
+        </tr>
+      </thead>
+      <tbody id="external-routes-body">
+        <tr>
+          <td colspan="5">Loading routes...</td>
+        </tr>
+      </tbody>
+    </table>
+
+
+    <h3>Add New Route</h3>
+    <p>
+      Interface: <input type="radio" name="new-interface" id="new-interface-external">External<input type="radio" name="new-interface" id="new-interface-internal">Internal<br>
+      IP: <input type="text" id="new-ip" placeholder="e.g. 10.0.0.0"><br>
+      Subnet: <input type="number" id="new-subnet" placeholder="e.g. 24"><br>
+      Next hop: <input type="text" id="new-next-hop" placeholder="e.g. 10.0.0.0"><br>
+      <button id="add-route-btn">Add Route</button>
+    </p>
+
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        function loadRoutes(type) {
+          var routesBody = document.getElementById(`${type}-routes-body`);
+          routesBody.innerHTML = "";
+          fetch(`/api/routes/${type}`)
+            .then(function(response) { return response.json(); })
+            .then(function(data) {
+              if (data.routes.length === 0) {
+                let row = document.createElement('tr');
+                row.innerHTML = "<td colspan='5'>No routes available</td>";
+                routesBody.appendChild(row);
+              } else {
+                data.routes.forEach(function(route) {
+                  let row = document.createElement('tr');
+
+                  let cellId = document.createElement('td');
+                  cellId.textContent = route.id;
+                  row.appendChild(cellId);
+
+                  let cellDest = document.createElement('td');
+                  cellDest.textContent = route.subnet ? route.ip : "-";
+                  row.appendChild(cellDest);
+
+                  let cellSubnet = document.createElement('td');
+                  cellSubnet.textContent = route.subnet ? route.subnet : "-";
+                  row.appendChild(cellSubnet);
+
+                  let cellNextHop = document.createElement('td');
+                  cellNextHop.textContent = route.next_hop;
+                  row.appendChild(cellNextHop);
+
+                  let cellActions = document.createElement('td');
+                  let delBtn = document.createElement('button');
+                  delBtn.textContent = "Delete";
+                  delBtn.addEventListener("click", function() {
+                    fetch(`/api/routes/${route.id}/${type}`, { method: 'DELETE' })
+                      .then(function(response) {
+                        if (!response.ok) throw new Error("Delete failed");
+                        return response.json();
+                      })
+                      .then(function(result) {
+                        alert("Route " + route.id + " deleted.");
+                        loadRoutes("external");
+                      })
+                      .catch(function(error) {
+                        alert("Error deleting route " + route.id);
+                      });
+                  });
+                  cellActions.appendChild(delBtn);
+                  row.appendChild(cellActions);
+
+                  routesBody.appendChild(row);
+                });
+              }
+            })
+            .catch(function(err) {
+              let row = document.createElement('tr');
+              row.innerHTML = "<td colspan='5'>Error retrieving routes</td>";
+              routesBody.appendChild(row);
+            });
+        }
+
+        loadRoutes("internal");
+        loadRoutes("external");
+
+        document.getElementById('add-route-btn').addEventListener('click', function() {
+          var interfaceExternal = document.getElementById('new-interface-external').checked;
+          var interfaceInternal = document.getElementById('new-interface-internal').checked;
+          var interface;
+          if (interfaceInternal) {
+            interface = 0;
+          } else if (interfaceExternal) {
+            interface = 1;
+          } else {
+            alert("Invalid interface supplied.");
+            return;
+          }
+          var ip = document.getElementById('new-ip').value;
+          var subnet = Number(document.getElementById('new-subnet').value);
+          var next_hop = document.getElementById('new-next-hop').value;
+          fetch(`/api/routes`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ interface: interface, ip: ip, subnet: subnet, next_hop: next_hop})
+          })
+          .then(function(response) {
+            if (!response.ok) throw new Error('Add route failed');
+            return response.json();
+          })
+          .then(function(result) {
+            alert("Route added successfully.");
+            loadRoutes("internal");
+            loadRoutes("external");
+          })
+          .catch(function(err) {
+            alert("Error adding route");
+          });
+        });
+      });
+    </script>
+  </body>
+</html>
+"""
+    return Response(body=html, headers={'Content-Type': 'text/html'})
+
+@app.route('/rules/<string:protocol>')
+def rules(request, protocol):
+    html = """
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Firewall Rules</title>
+    <link rel="stylesheet" href="/main.css">
+  </head>
+  <body>
+    <h1>Firewall Rules</h1>
+    <nav>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+    </nav>
+    <div style="display: flex; flex-direction: column; margin-top: 1rem">
+      <a href="/rules/udp">UDP</a>
+      <a href="/rules/tcp">TCP</a>
+      <a href="/rules/icmp">ICMP</a>
+    </div>
+    <h1>INSERT_PROTOCOL_UPPER rules</h1>
+    <h2>Internal Rules</h2>
+    <div class="default-action-container">
+      <h4>Default action</h4>
+      <div>
+        <select name="internal-default-action" id="internal-default-action">
+          <option value="1">Allow</option>
+          <option value="2">Drop</option>
+          <option value="3">Connect</option>
+        </select>
+        <button id="internal-set-default-action-btn">Update Default</button>
+      </div>
+    </div>
+    <table border="1">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Source IP</th>
+          <th>Source Port</th>
+          <th>Destination IP</th>
+          <th>Destination Port</th>
+          <th>Source Subnet</th>
+          <th>Destination Subnet</th>
+          <th>Action</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody id="internal-rules-body">
+        <tr><td colspan="5">Loading rules...</td></tr>
+      </tbody>
+    </table>
+    <h2>External Rules</h2>
+    <div class="default-action-container">
+      <h4>Default action</h4>
+      <div>
+        <select name="external-default-action" id="external-default-action">
+          <option value="">...</option>
+          <option value="1">Allow</option>
+          <option value="2">Drop</option>
+          <option value="3">Connect</option>
+        </select>
+        <button id="external-set-default-action-btn">Update Default</button>
+      </div>
+    </div>
+    <table border="1">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Source IP</th>
+          <th>Source Port</th>
+          <th>Destination IP</th>
+          <th>Destination Port</th>
+          <th>Source Subnet</th>
+          <th>Destination Subnet</th>
+          <th>Action</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody id="external-rules-body">
+        <tr><td colspan="5">Loading rules...</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Add New Rule</h2>
+      Interface: <input type="radio" name="new-interface" id="new-interface-internal">Internal<input type="radio" name="new-interface" id="new-interface-external">External<br>
+      Source IP: <input type="text" id="new-src-ip" placeholder="e.g. 192.168.10.3"><br>
+      Source Port: <input type="number" id="new-src-port" placeholder="e.g. 24"><br>
+      Source Subnet: <input type="number" id="new-src-subnet" placeholder="e.g. 16"><br>
+      Destination IP: <input type="text" id="new-dest-ip" placeholder="e.g. 192.168.10.3"><br>
+      Destination Port: <input type="number" id="new-dest-port" placeholder="e.g. 24"><br>
+      Destination Subnet: <input type="number" id="new-dest-subnet" placeholder="e.g. 16"><br>
+      Action
+      <select name="action" id="new-action">
+        <option value="">Rule Action</option>
+        <option value="1">Allow</option>
+        <option value="2">Drop</option>
+        <option value="3">Connect</option>
+      </select>
+      <button id="add-rule-btn">Add Rule</button>
+    </p>
+
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        function loadRules(type) {
+          var rulesBody = document.getElementById(`${type}-rules-body`);
+          rulesBody.innerHTML = "";
+          const defaultAction = document.getElementById(`${type}-default-action`);
+          fetch(`/api/rules/INSERT_PROTOCOL/${type}`)
+            .then(function(response) { return response.json(); })
+            .then(function(data) {
+              for (let i = 0; i < defaultAction.options.length; i++) {
+                if (data.default_action == defaultAction.options[i].value) {
+                  defaultAction.options[i].selected = true;
+                } else {
+                  defaultAction.options[i].selected = false;
+                }
+              }
+              if (data.rules.length === 0) {
+                var row = document.createElement('tr');
+                row.innerHTML = "<td colspan='5'>No rules available</td>";
+                rulesBody.appendChild(row);
+              } else {
+                data.rules.forEach(function(rule) {
+                  var row = document.createElement('tr');
+                  let id = row.insertCell();
+                  id.textContent = rule.id;
+                  let srcIp = row.insertCell();
+                  srcIp.textContent = rule.src_subnet ? rule.src_ip : "-";
+                  let srcPort = row.insertCell();
+                  srcPort.textContent = rule.src_port_any ? "-" : rule.src_port;
+                  let destIp = row.insertCell();
+                  destIp.textContent = rule.dest_subnet ? rule.dest_ip : "-";
+                  let destPort = row.insertCell();
+                  destPort.textContent = rule.dest_port_any ? "-" : rule.dest_port;
+                  let srcSubnet = row.insertCell();
+                  srcSubnet.textContent = rule.src_subnet ? rule.src_subnet : "-";
+                  let destSubnet = row.insertCell();
+                  destSubnet.textContent = rule.dest_subnet ? rule.dest_subnet : "-";
+                  let action = row.insertCell();
+                  action.textContent = rule.action;
+                  let buttonCell = row.insertCell();
+                  let button = document.createElement("button");
+                  button.textContent = "Delete";
+                  button.addEventListener("click", () => {
+                    deleteRule(rule.id, type);
+                  });
+                  buttonCell.appendChild(button);
+                  console.log("This is inner html:" + row.innerHTML);
+                  rulesBody.appendChild(row);
+                });
+              }
+            })
+            .catch(function(err) {
+              var row = document.createElement('tr');
+              row.innerHTML = "<td colspan='5'>Error retrieving rules</td>";
+              rulesBody.appendChild(row);
+            });
+        }
+
+        window.deleteRule = function(ruleId, type) {
+          fetch(`/api/rules/INSERT_PROTOCOL/${ruleId}/${type}`, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' }
+          })
+          .then(function(response) {
+            if (!response.ok) throw new Error("Delete failed");
+            return response.json();
+          })
+          .then(function(result) {
+            alert("Rule " + ruleId + " deleted.");
+            loadRules("internal");
+            loadRules("external");
+          })
+          .catch(function(error) {
+            alert("Error deleting rule " + ruleId);
+          });
+        }
+
+        document.getElementById(`external-set-default-action-btn`).addEventListener('click', function() {
+          const newDefaultAction = document.getElementById(`external-default-action`).value;
+          fetch(`/api/rules/INSERT_PROTOCOL/default/${newDefaultAction}/external`, {
+            method: 'POST',
+          })
+          .then(function(response) {
+            if (!response.ok) throw new Error("Update default action failed");
+            return response.json();
+          })
+          .then(function(result) {
+            alert("Updated default action successfully.");
+          })
+          .catch(function(err) {
+            alert("Error updating default action");
+          });
+        });
+
+        document.getElementById(`internal-set-default-action-btn`).addEventListener('click', function() {
+          const newDefaultAction = document.getElementById(`internal-default-action`).value;
+          fetch(`/api/rules/INSERT_PROTOCOL/default/${newDefaultAction}/internal`, {
+            method: 'POST',
+          })
+          .then(function(response) {
+            if (!response.ok) throw new Error("Update default action failed");
+            return response.json();
+          })
+          .then(function(result) {
+            alert("Updated default action successfully.");
+          })
+          .catch(function(err) {
+            alert("Error updating default action");
+          });
+        });
+
+        document.getElementById('add-rule-btn').addEventListener('click', function() {
+          var interfaceInternal = document.getElementById('new-interface-internal').checked;
+          var interfaceExternal = document.getElementById('new-interface-external').checked;
+          var interface;
+          if (interfaceInternal) {
+            interface = 1;
+          } else if (interfaceExternal) {
+            interface = 0;
+          } else {
+            alert("Invalid interface supplied.");
+            return;
+          }
+          var srcIp = document.getElementById('new-src-ip').value;
+          var srcPort = document.getElementById('new-src-port').value;
+          var srcSubnet = Number(document.getElementById('new-src-subnet').value);
+          var destIp = document.getElementById('new-dest-ip').value;
+          var destPort = document.getElementById('new-dest-port').value;
+          var destSubnet = Number(document.getElementById('new-dest-subnet').value);
+          var action = Number(document.getElementById('new-action').value);
+          const body = JSON.stringify({
+            interface: interface,
+            src_ip: srcIp,
+            src_port: srcPort,
+            src_subnet: srcSubnet,
+            dest_ip: destIp,
+            dest_port: destPort,
+            dest_subnet: destSubnet,
+            action: action,
+          });
+          fetch('/api/rules/INSERT_PROTOCOL', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: body,
+          })
+          .then(function(response) {
+            if (!response.ok) throw new Error("Add rule failed");
+            return response.json();
+          })
+          .then(function(result) {
+            alert("Rule added successfully.");
+            loadRules("internal");
+            loadRules("external");
+          })
+          .catch(function(err) {
+            alert("Error adding rule");
+          });
+        });
+
+        loadRules("internal");
+        loadRules("external");
+      });
+    </script>
+  </body>
+</html>
+"""
+    html = html.replace("INSERT_PROTOCOL_UPPER", protocol.upper())
+    html = html.replace("INSERT_PROTOCOL", protocol)
+    return Response(body=html, headers={'Content-Type': 'text/html'})
+
+@app.route('/rules')
+def rules(request):
+    html = """
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Firewall Rules</title>
+    <link rel="stylesheet" href="/main.css">
+  </head>
+  <body>
+    <h1>Firewall Rules</h1>
+    <nav>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+    </nav>
+    <div style="display: inline-block; margin-top: 1rem">
+      <a href="/rules/udp">UDP</a>
+      <a href="/rules/tcp">TCP</a>
+      <a href="/rules/icmp">ICMP</a>
+    </div>
+  </body>
+</html>
+"""
+    return Response(body=html, headers={'Content-Type': 'text/html'})
+
+@app.route("/main.css")
+def css(request):
+    css = """
+body {
+  font-family: Arial;
+}
+
+.monospace {
+  font-family: monospace;
+}
+
+.default-action-container {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+"""
+    return Response(body=css, headers={'Content-Type': 'text/css'})
+
+app.run(debug=True, port=80)

--- a/include/lions/firewall/arp.h
+++ b/include/lions/firewall/arp.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+#include <os/sddf.h>
+#include <sddf/util/util.h>
+#include <sddf/timer/client.h>
+#include <lions/firewall/config.h>
+#include <lions/firewall/protocols.h>
+
+typedef enum {
+    /* no error */
+    ARP_ERR_OKAY = 0,
+    /* data structure is full */
+	ARP_ERR_FULL,
+    /* arp entry invalid */
+    ARP_ERR_INVALID
+} fw_arp_error_t;
+
+typedef enum {
+    /* entry is not valid */
+    ARP_STATE_INVALID = 0,
+    /* IP is pending an arp response */
+    ARP_STATE_PENDING,
+    /* IP is unreachable */
+    ARP_STATE_UNREACHABLE,
+    /* IP is reachable, MAC address is valid */
+    ARP_STATE_REACHABLE
+} fw_arp_entry_state_t;
+
+typedef struct fw_arp_entry {
+    /* state of this entry */
+    uint8_t state;
+    /* IP address */
+    uint32_t ip;
+    /* MAC of IP if IP is reachable */
+    uint8_t mac_addr[ETH_HWADDR_LEN];
+    /* bitmap of clients that initiated the request */
+    uint8_t client;
+    /* number of arp requests sent for this IP address */
+    uint8_t num_retries;
+} fw_arp_entry_t;
+
+typedef struct fw_arp_table {
+    /* arp entries */
+    fw_arp_entry_t *entries;
+    /* capacity of arp table */
+    uint16_t capacity;
+} fw_arp_table_t;
+
+typedef struct fw_arp_request {
+    /* IP address */
+    uint32_t ip;
+    /* MAC address for IP if response and state is valid */
+    uint8_t mac_addr[ETH_HWADDR_LEN];
+    /* state of arp response */
+    uint8_t state;
+} fw_arp_request_t;
+
+/**
+ * Initialise the arp table data structure.
+ *
+ * @param table address of arp table.
+ * @param entries virtual address of arp entries.
+ * @param capacity capacity of arp table.
+ */
+static void fw_arp_table_init(fw_arp_table_t *table,
+                              void *entries, 
+                              uint16_t capacity)
+{
+    table->entries = (fw_arp_entry_t *)entries;
+    table->capacity = capacity;
+}
+
+/**
+ * Find an arp entry for an ip address.
+ *
+ * @param table address of arp table.
+ * @param ip ip address to lookup.
+ *
+ * @return address of arp entry of NULL.
+ */
+static fw_arp_entry_t *fw_arp_table_find_entry(fw_arp_table_t *table,
+                                               uint32_t ip)
+{
+    for (uint16_t i = 0; i < table->capacity; i++) {
+        fw_arp_entry_t *entry = table->entries + i;
+        if (entry->state == ARP_STATE_INVALID) {
+            continue;
+        }
+
+        if (entry->ip == ip) {
+            return entry;
+        }
+    }
+
+    return NULL;
+}
+
+/**
+ * Create an arp response from an arp entry.
+ *
+ * @param entry address of arp entry to form response.
+ *
+ * @return arp response from entry.
+ */
+static fw_arp_request_t fw_arp_response_from_entry(fw_arp_entry_t *entry)
+{
+    fw_arp_request_t response = { 0 };
+    if (entry == NULL) {
+        return response;
+    }
+
+    response.ip = entry->ip;
+    response.state = entry->state;
+    if (entry->state == ARP_STATE_REACHABLE) {
+        memcpy(&response.mac_addr, &entry->mac_addr, ETH_HWADDR_LEN);
+    }
+
+    return response;
+}
+
+/**
+ * Add an entry to the arp table.
+ *
+ * @param table address of arp table.
+ * @param timer_ch channel to sddf timer subsystem.
+ * @param state state of arp entry.
+ * @param ip ip address of arp entry.
+ * @param mac_addr mac address of arp entry or NULL.
+ * @param client client that initiated arp request.
+ *
+ * @return error status.
+ */
+static fw_arp_error_t fw_arp_table_add_entry(fw_arp_table_t *table,
+                                       fw_arp_entry_state_t state,
+                                       uint32_t ip,
+                                       uint8_t *mac_addr,
+                                       uint8_t client)
+{
+    if (state == ARP_STATE_REACHABLE && mac_addr == NULL) {
+        return ARP_ERR_INVALID;
+    }
+
+    fw_arp_entry_t *slot = NULL;
+    for (uint16_t i = 0; i < table->capacity; i++) {
+        fw_arp_entry_t *entry = table->entries + i;
+
+        if (entry->state == ARP_STATE_INVALID) {
+            if (slot == NULL) {
+                slot = entry;
+            }
+            continue;
+        }
+
+        /* Check for existing entries for this ip - there should only be one */
+        if (entry->ip == ip) {
+            slot = entry;
+            break;
+        }
+    }
+
+    if (slot == NULL) {
+        return ARP_ERR_FULL;
+    }
+
+    slot->state = state;
+    slot->ip = ip;
+    if (state == ARP_STATE_REACHABLE) {
+        memcpy(&slot->mac_addr, mac_addr, ETH_HWADDR_LEN);
+    }
+    slot->client = BIT(client);
+    slot->num_retries = 0;
+
+    return ARP_ERR_OKAY;
+}

--- a/include/lions/firewall/array_functions.h
+++ b/include/lions/firewall/array_functions.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sddf/util/util.h>
+#include <string.h>
+
+/**
+ * Shift all array indices past index_to_remove one index lower.
+ * Can be used for a general array with entries stored consecutively.
+ *
+ * @param array address of the array.
+ * @param entry_size size of each entry.
+ * @param array_len length of array including index to remove.
+ * @param index_to_remove index of the array to be removed.
+ */
+static void generic_array_shift(void *array,
+                                uint32_t entry_size,
+                                uint32_t array_len,
+                                uint32_t index_to_remove)
+{
+    unsigned char* arr = (unsigned char *) array;
+    uint32_t shift_len = (array_len - index_to_remove - 1) * entry_size;
+    if (shift_len > 0) {
+        uint32_t byte_offset = index_to_remove * entry_size;
+        memmove(arr + byte_offset, arr + byte_offset + entry_size, shift_len);
+    }
+}

--- a/include/lions/firewall/common.h
+++ b/include/lions/firewall/common.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sddf/util/util.h>
+
+static inline uint32_t htonl(uint32_t n)
+{
+    return (n & 0xff) << 24 | (n & 0xff00) << 8 | ((n >> 8) & 0xff00) | n >> 24;
+}
+
+/* Subnet value of N means IPs must match on highest N bits. IP addresses
+are stored big-endian, so must first be shifted for subnet match. */
+#define subnet_mask(n) htonl((uint32_t)(0xffffffffUL << (32 - (n))))
+
+/* Firewall ID number used by components to identify which interface they
+are connected to */
+#define FW_EXTERNAL_INTERFACE_ID 0
+#define FW_INTERNAL_INTERFACE_ID 1
+
+/* Firewall component print formatting string to identify which interface
+component is printing */
+static const char *fw_frmt_str[] = {
+    "EXT --> INT | ",
+    "INT --> EXT | "
+};
+
+#define IPV4_ADDR_BUFLEN 16
+
+static char ip_addr_buf0[IPV4_ADDR_BUFLEN];
+static char ip_addr_buf1[IPV4_ADDR_BUFLEN];
+
+/**
+ * Convert a big-endian ip address integer to a string.
+ *
+ * @param ip big-endian ip address.
+ * @param buf buffer used to output ip address as a string.
+ *
+ * @return buffer or NULL upon failure.
+ */
+static char *ipaddr_to_string(uint32_t ip,
+                              char *buf)
+{
+    char inv[3], *rp;
+    uint8_t *ap, rem, n, i;
+    int len = 0;
+
+    rp = buf;
+    ap = (uint8_t *)&ip;
+    for (n = 0; n < 4; n++) {
+        i = 0;
+        do {
+            rem = *ap % (uint8_t)10;
+            *ap /= (uint8_t)10;
+            inv[i++] = (char)('0' + rem);
+        } while (*ap);
+        while (i--) {
+            if (len++ >= IPV4_ADDR_BUFLEN) {
+                return NULL;
+            }
+            *rp++ = inv[i];
+        }
+        if (len++ >= IPV4_ADDR_BUFLEN) {
+            return NULL;
+        }
+        *rp++ = '.';
+        ap++;
+    }
+    *--rp = 0;
+    return buf;
+}

--- a/include/lions/firewall/config.h
+++ b/include/lions/firewall/config.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <os/sddf.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <sddf/resources/common.h>
+#include <sddf/resources/device.h>
+#include <sddf/network/config.h>
+#include <sddf/network/constants.h>
+
+#define FW_MAX_FW_CLIENTS 61
+#define FW_MAX_FILTERS 61
+
+#define FW_NUM_ARP_REQUESTER_CLIENTS 2
+#define FW_NUM_INTERFACES 2
+
+#define FW_DEBUG_OUTPUT 1
+
+typedef struct fw_connection_resource {
+    region_resource_t queue;
+    uint16_t capacity;
+    uint8_t ch;
+} fw_connection_resource_t;
+
+typedef struct fw_data_connection_resource {
+    fw_connection_resource_t conn;
+    device_region_resource_t data;
+} fw_data_connection_resource_t;
+
+typedef struct fw_net_virt_tx_config {
+    uint8_t interface;
+    fw_data_connection_resource_t active_clients[FW_MAX_FW_CLIENTS];
+    uint8_t num_active_clients;
+    fw_data_connection_resource_t free_clients[FW_MAX_FW_CLIENTS];
+    uint8_t num_free_clients;
+} fw_net_virt_tx_config_t;
+
+typedef struct fw_net_virt_rx_config {
+    uint8_t interface;
+    uint16_t active_client_protocols[SDDF_NET_MAX_CLIENTS];
+    fw_connection_resource_t free_clients[FW_MAX_FW_CLIENTS];
+    uint8_t num_free_clients;
+} fw_net_virt_rx_config_t;
+
+typedef struct fw_arp_connection {
+    region_resource_t request;
+    region_resource_t response;
+    uint16_t capacity;
+    uint8_t ch;
+} fw_arp_connection_t;
+
+typedef struct fw_arp_requester_config {
+    uint8_t interface;
+    uint8_t mac_addr[ETH_HWADDR_LEN];
+    uint32_t ip;
+    fw_arp_connection_t arp_clients[FW_NUM_ARP_REQUESTER_CLIENTS];
+    uint8_t num_arp_clients;
+    region_resource_t arp_cache;
+    uint16_t arp_cache_capacity;
+} fw_arp_requester_config_t;
+
+typedef struct fw_arp_responder_config {
+    uint8_t interface;
+    uint8_t mac_addr[ETH_HWADDR_LEN];
+    uint32_t ip;
+} fw_arp_responder_config_t;
+
+typedef struct fw_webserver_router_config {
+    uint8_t interface;
+    uint8_t routing_ch;
+    region_resource_t routing_table;
+    uint16_t routing_table_capacity;
+} fw_webserver_router_config_t;
+
+typedef struct fw_router_config {
+    uint8_t interface;
+    uint8_t mac_addr[ETH_HWADDR_LEN];
+    uint32_t ip;
+    uint32_t out_ip;
+    uint8_t out_subnet;
+    fw_connection_resource_t rx_free;
+    fw_connection_resource_t rx_active;
+    fw_connection_resource_t tx_active;
+    region_resource_t data;
+    fw_arp_connection_t arp_queue;
+    region_resource_t arp_cache;
+    uint16_t arp_cache_capacity;
+    region_resource_t packet_queue;
+    fw_webserver_router_config_t webserver;
+    fw_connection_resource_t icmp_module;
+    fw_connection_resource_t filters[FW_MAX_FILTERS];
+    uint8_t num_filters;
+} fw_router_config_t;
+
+typedef struct fw_icmp_module_config {
+    uint32_t ips[FW_NUM_INTERFACES];
+    fw_connection_resource_t routers[FW_NUM_INTERFACES];
+    uint8_t num_interfaces;
+} fw_icmp_module_config_t;
+
+typedef struct fw_webserver_filter_config {
+    uint8_t interface;
+    uint16_t protocol;
+    uint8_t ch;
+    uint8_t default_action;
+    region_resource_t rules;
+    uint16_t rules_capacity;
+} fw_webserver_filter_config_t;
+
+typedef struct fw_filter_config {
+    uint8_t mac_addr[ETH_HWADDR_LEN];
+    uint32_t ip;
+    uint16_t instances_capacity;
+    fw_connection_resource_t router;
+    fw_webserver_filter_config_t webserver;
+    region_resource_t internal_instances;
+    region_resource_t external_instances;
+} fw_filter_config_t;
+
+typedef struct fw_webserver_interface_config {
+    uint8_t mac_addr[ETH_HWADDR_LEN];
+    uint32_t ip;
+    fw_webserver_router_config_t router;
+    fw_webserver_filter_config_t filters[FW_MAX_FILTERS];
+    uint8_t num_filters;
+} fw_webserver_interface_config_t;
+
+typedef struct fw_webserver_config {
+    uint8_t interface;
+    fw_connection_resource_t rx_active;
+    region_resource_t data;
+    fw_connection_resource_t rx_free;
+    fw_arp_connection_t arp_queue;
+    fw_webserver_interface_config_t interfaces[FW_NUM_INTERFACES];
+    uint8_t num_interfaces;
+} fw_webserver_config_t;

--- a/include/lions/firewall/filter.h
+++ b/include/lions/firewall/filter.h
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <os/sddf.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <sddf/util/util.h>
+#include <lions/firewall/common.h>
+
+typedef enum {
+    /* no error */
+    FILTER_ERR_OKAY = 0,
+    /* data structure is full */
+	FILTER_ERR_FULL,
+    /* duplicate entry exists */
+	FILTER_ERR_DUPLICATE,
+    /* entry clashes with existing entry */
+    FILTER_ERR_CLASH,
+    /* rule id does not point to a valid entry */
+    FILTER_ERR_INVALID_RULE_ID
+} fw_filter_err_t;
+
+static const char *fw_filter_err_str[] = {
+    "Ok.",
+    "Out of memory error.",
+    "Duplicate entry.",
+    "Clashing entry.",
+    "Invalid rule ID."
+};
+
+typedef enum {
+    /* no rule exists */
+    FILTER_ACT_NONE,
+    /* allow traffic */
+	FILTER_ACT_ALLOW,
+    /* drop traffic */
+	FILTER_ACT_DROP,
+    /* allow traffic, and additionally any return traffic */
+    FILTER_ACT_CONNECT,
+    /* traffic is return traffic from a connect rule */
+    FILTER_ACT_ESTABLISHED
+} fw_action_t;
+
+static const char *fw_filter_action_str[] = {
+    "No rule",
+    "Allow",
+    "Drop",
+    "Connect",
+    "Established"
+};
+
+typedef struct fw_rule {
+    /* whether this is a valid rule */
+    bool valid;
+    /* action to be applied to traffic matching rule */
+    uint8_t action;
+    /* source IP */
+    uint32_t src_ip;
+    /* destination IP */
+    uint32_t dst_ip;
+    /* source port number */
+    uint16_t src_port;
+    /* destination port number */
+    uint16_t dst_port;
+    /* source subnet, 0 is any IP */
+    uint8_t src_subnet;
+    /* destination subnet, 0 is any IP */
+    uint8_t dst_subnet;
+    /* rule applies to any source port */
+    bool src_port_any;
+    /* rule applies to any destination port */
+    bool dst_port_any;
+} fw_rule_t;
+
+/**
+ * Instances are created by filters if traffic matches with a connect rule.
+ * If this is the case, return traffic should be permitted also, thus the
+ * filter will create an instance in shared memory so the matching filter
+ * can search for and identify return traffic.
+ */
+typedef struct fw_instance {
+    /* source ip of traffic */
+    uint32_t src_ip;
+    /* destination ip of traffic */
+    uint32_t dst_ip;
+    /* source port of traffic */
+    uint16_t src_port;
+    /* destination port of traffic */
+    uint16_t dst_port;
+    /* ID of the rule this instance was created from. Allows instances
+    to be removed upon rule removal */
+    uint16_t rule_id;
+    /* instance was created after matching with the filter's default action */
+    bool default_action;
+    /* whether this is a valid instance */
+    bool valid;
+} fw_instance_t;
+
+typedef struct fw_filter_state {
+    /* filter rules */
+    fw_rule_t *rules;
+    /* capacity of filter rules */
+    uint16_t rules_capacity;
+    /* instances created by this filter,
+    to be searched by neighbour filter */
+    fw_instance_t *internal_instances;
+    /* instances created by neighbour filter,
+    to be searched by this filter */
+    fw_instance_t *external_instances;
+    /* capacity of both instance tables */
+    uint16_t instances_capacity;
+    /* default action of filter to be applied
+    if no other matches */
+    fw_action_t default_action;
+} fw_filter_state_t;
+
+/* PP call parameters for webserver to call filters and update rules */
+#define FW_SET_DEFAULT_ACTION 0
+#define FW_ADD_RULE 1
+#define FW_DEL_RULE 2
+
+typedef enum {
+    FILTER_PROTO_UDP,
+    FILTER_PROTO_TCP,
+    FILTER_PROTO_IMCP
+} fw_protocol_id_t;
+
+typedef enum {
+    FILTER_ARG_ACTION = 0,
+    FILTER_ARG_RULE_ID = 1,
+    FILTER_ARG_SRC_IP = 2,
+    FILTER_ARG_SRC_PORT = 3,
+    FILTER_ARG_DST_IP = 4,
+    FILTER_ARG_DST_PORT = 5,
+    FILTER_ARG_SRC_SUBNET = 6,
+    FILTER_ARG_DST_SUBNET = 7,
+    FILTER_ARG_SRC_ANY_PORT = 8,
+    FILTER_ARG_DST_ANY_PORT = 9
+} fw_args_t;
+
+typedef enum {
+    FILTER_RET_ERR = 0,
+    FILTER_RET_RULE_ID = 1
+} fw_ret_args_t;
+
+/**
+ * Initialise filter state.
+ *
+ * @param state address of filter state.
+ * @param rules address of rules table.
+ * @param rules_capacity capacity of rules table.
+ * @param internal_instances address of internal instances.
+ * @param external_instances address of external instances.
+ * @param instances_capacity capacity of instance tables.
+ * @param default_action default action of filter.
+ */
+static void fw_filter_state_init(fw_filter_state_t *state, 
+                                 void *rules, 
+                                 uint16_t rules_capacity,
+                                 void *internal_instances, 
+                                 void *external_instances, 
+                                 uint16_t instances_capacity,
+                                 fw_action_t default_action)
+{
+    state->rules = (fw_rule_t *)rules;
+    state->rules_capacity = rules_capacity;
+    state->internal_instances = (fw_instance_t *)internal_instances;
+    state->external_instances = (fw_instance_t *)external_instances;
+    state->instances_capacity = instances_capacity;
+    state->default_action = default_action;
+}
+
+/**
+ * Add a filtering rule.
+ *
+ * @param state address of filter state.
+ * @param src_ip source ip of traffic rule applies to.
+ * @param src_port source port of traffic rule applies to.
+ * @param dst_ip destination ip of traffic rule applies to.
+ * @param dst_port destination port of traffic rule applies to.
+ * @param src_subnet subnet bits of source ip traffic rule applies to.
+ * @param dst_subnet subnet bits of destination ip traffic rule applies to.
+ * @param src_port_any whether rule applies to any source port.
+ * @param dst_port_any whether rule applies to any destination port.
+ * @param action action to be applied to traffic matching rule.
+ * @param rule_id address of rule id to be set upon successful rule creation.
+ * 
+ * @return error status.
+ */
+static fw_filter_err_t fw_filter_add_rule(fw_filter_state_t *state,
+                                          uint32_t src_ip,
+                                          uint16_t src_port,
+                                          uint32_t dst_ip,
+                                          uint16_t dst_port,
+                                          uint8_t src_subnet,
+                                          uint8_t dst_subnet,
+                                          bool src_port_any,
+                                          bool dst_port_any,
+                                          fw_action_t action,
+                                          uint16_t *rule_id)
+{
+    fw_rule_t *empty_slot = NULL;
+    for (uint16_t i = 0; i < state->rules_capacity; i++) {
+        fw_rule_t *rule = (fw_rule_t *)(state->rules + i);
+
+        if (!rule->valid) {
+            if (empty_slot == NULL) {
+                empty_slot = rule;
+            }
+            continue;
+        }
+
+        /* Check that this entry won't cause clashes */
+
+        /* One rule applies to any src port, one applies to a specific src port */
+        if ((src_port_any && !rule->src_port_any) || (!src_port_any && rule->src_port_any)) {
+            continue;
+        }
+
+        /* One rule applies to any dst port, one applies to a specific dst port */
+        if ((dst_port_any && !rule->dst_port_any) || (!dst_port_any && rule->dst_port_any)) {
+            continue;
+        }
+
+        /* One rule applies to one port, one applies to another */
+        if (src_port != rule->src_port || dst_port != rule->dst_port) {
+            continue;
+        }
+
+        /* One rule applies to a larger subnet than the other */
+        if (src_subnet != rule->src_subnet || dst_subnet != rule->dst_subnet) {
+            continue;
+        }
+
+        /* Rules apply to different source subnets */
+        if ((subnet_mask(src_subnet) & src_ip) != (subnet_mask(rule->src_subnet) & rule->src_ip)) {
+            continue;
+        }
+
+        /* Rules apply to different destination subnets */
+        if ((subnet_mask(dst_subnet) & dst_ip) != (subnet_mask(rule->dst_subnet) & rule->dst_ip)) {
+            continue;
+        }
+
+        /* There is a clash! */
+        if (action == rule->action) {
+            return FILTER_ERR_DUPLICATE;
+        } else {
+            return FILTER_ERR_CLASH;
+        }
+    }
+
+    if (empty_slot == NULL) {
+        return FILTER_ERR_FULL;
+    }
+
+    empty_slot->valid = true;
+    empty_slot->src_ip = subnet_mask(src_subnet) & src_ip;
+    empty_slot->src_port = src_port;
+    empty_slot->dst_ip = subnet_mask(dst_subnet) & dst_ip;
+    empty_slot->dst_port = dst_port;
+    empty_slot->src_subnet = src_subnet;
+    empty_slot->dst_subnet = dst_subnet;
+    empty_slot->src_port_any = src_port_any;
+    empty_slot->dst_port_any = dst_port_any;
+    empty_slot->action = action;
+    *rule_id = empty_slot - state->rules;
+
+    return FILTER_ERR_OKAY;
+}
+
+/**
+ * Create an instance. To be used after traffic matches with a connect rule,
+ * allowing neighbour filter to permit return traffic.
+ *
+ * @param state address of filter state.
+ * @param src_ip source ip of instance traffic.
+ * @param src_port source port of instance traffic.
+ * @param dst_ip destination ip of instance traffic.
+ * @param dst_port destination port of instance traffic.
+ * @param default_action whether connect rule was matched via filter's default action.
+ * @param rule_id id of connect rule.
+ * 
+ * @return error status.
+ */
+static fw_filter_err_t fw_filter_add_instance(fw_filter_state_t *state,
+                                              uint32_t src_ip,
+                                              uint16_t src_port,
+                                              uint32_t dst_ip,
+                                              uint16_t dst_port,
+                                              bool default_action,
+                                              uint16_t rule_id)
+{
+    fw_instance_t *empty_slot = NULL;
+    for (uint16_t i = 0; i < state->instances_capacity; i++) {
+        fw_instance_t *instance = state->internal_instances + i;
+
+        if (!instance->valid) {
+            if (empty_slot == NULL) {
+                empty_slot = instance;
+            }
+            continue;
+        }
+
+        /* Connection has already been established */
+        if (((instance->default_action && default_action) || (instance->rule_id == rule_id)) &&
+            instance->src_ip == src_ip &&
+            instance->src_port == src_port &&
+            instance->dst_ip == dst_ip &&
+            instance->dst_port == dst_port)
+        {
+            return FILTER_ERR_DUPLICATE;
+        }
+    }
+
+    if (empty_slot == NULL) {
+        return FILTER_ERR_FULL;
+    }
+
+    empty_slot->valid = true;
+    empty_slot->default_action = default_action;
+    empty_slot->rule_id = rule_id;
+    empty_slot->src_ip = src_ip;
+    empty_slot->src_port = src_port;
+    empty_slot->dst_ip = dst_ip;
+    empty_slot->dst_port = dst_port;
+
+    return FILTER_ERR_OKAY;
+}
+
+/**
+ * Find the filter action to be applied for a given source and destination ip
+ * and port number. First external instances are checked so that return traffic
+ * may be permitted. If traffic is not return traffic from a neighbour filter's
+ * connection, the most specific matching filter rule is returned.
+ *
+ * @param state address of filter state.
+ * @param src_ip source ip to match.
+ * @param src_port source port to match.
+ * @param dst_ip destination ip to match.
+ * @param dst_port destination port to match.
+ * @param rule_id id of matching rule. Unmodified if no match.
+ * 
+ * @return filter action to be applied. None is returned if no match is found.
+ */
+static fw_action_t fw_filter_find_action(fw_filter_state_t *state,
+                                         uint32_t src_ip,
+                                         uint16_t src_port,
+                                         uint32_t dst_ip,
+                                         uint16_t dst_port,
+                                         uint16_t *rule_id)
+{
+    /* Fist check external instances */
+    for (uint16_t i = 0; i < state->instances_capacity; i++) {
+        fw_instance_t *instance = state->external_instances + i;
+
+        if (!instance->valid) {
+            continue;
+        }
+
+        if (instance->src_port != dst_port || instance->dst_port != src_port) {
+            continue;
+        }
+
+        if (instance->src_ip != dst_ip || instance->dst_ip != src_ip) {
+            continue;
+        }
+
+        *rule_id = instance->rule_id;
+        return FILTER_ACT_ESTABLISHED;
+    }
+
+    /* Check rules */
+    fw_rule_t *match = NULL;
+    for (uint16_t i = 0; i < state->rules_capacity; i++) {
+        fw_rule_t *rule = state->rules + i;
+
+        if (!rule->valid) {
+            continue;
+        }
+
+        /* Check port numbers first */
+        if ((!rule->src_port_any && rule->src_port != src_port) || (!rule->dst_port_any && rule->dst_port != dst_port)) {
+            continue;
+        }
+
+        /* Match on src addr first */
+        if ((subnet_mask(rule->src_subnet) & src_ip) != (subnet_mask(rule->src_subnet) & rule->src_ip)) {
+            continue;
+        }
+
+        /* Match on src addr first */
+        if ((subnet_mask(rule->dst_subnet) & dst_ip) != (subnet_mask(rule->dst_subnet) & rule->dst_ip)) {
+            continue;
+        }
+
+        /* This if the first match we've found */
+        if (match == NULL) {
+            match = rule;
+        }
+
+        /* We give priority to source matches over destination matches */
+        if (rule->src_subnet == match->src_subnet) {
+            if (rule->dst_subnet == match->dst_subnet) {
+                if (rule->src_port_any == match->src_port_any) {
+                    if (!rule->dst_port_any && match->dst_port_any) {
+                        match = rule; /* destination port number is a stronger match */
+                    }
+                } else if (!rule->src_port_any && match->src_port_any) {
+                    match = rule; /* source port number is a stronger match */
+                }
+            } else if (rule->dst_subnet > match->dst_subnet) { /* destination subnet is a longer match */
+                match = rule;
+            }
+        } else if (rule->src_subnet > match->src_subnet) {
+            match = rule; /* source subnet is a longer match */
+        }
+    }
+
+    if (match) {
+        *rule_id = match - state->rules;
+        return match->action;
+    }
+
+    return FILTER_ACT_NONE;
+}
+
+/**
+ * Remove instances associated with a rule. To be used when a rule is
+ * deleted or default action is changed.
+ * 
+ * @param state address of filter state.
+ * @param default_action whether instances of the default action should be removed.
+ * @param rule_id ID of rule that has been deleted.
+ *
+ * @return error status.
+ */
+static fw_filter_err_t fw_filter_remove_instances(fw_filter_state_t *state,
+                                                  bool default_action,
+                                                  uint16_t rule_id)
+{
+    for (uint16_t i = 0; i < state->instances_capacity; i++) {
+        fw_instance_t *instance = state->internal_instances + i;
+        if (!instance->valid) {
+            continue;
+        }
+        
+        if (default_action && (default_action != instance->default_action)) {
+            continue;
+        }
+        
+        if (!default_action && (rule_id != instance->rule_id)) {
+            continue;
+        }
+
+        instance->valid = false;
+    }
+
+    return FILTER_ERR_OKAY;
+}
+
+/**
+ * Update filter's default action.
+ * 
+ * @param state address of filter state.
+ * @param new_action new default action.
+ *
+ * @return error status.
+ */
+static fw_filter_err_t fw_filter_update_default_action(fw_filter_state_t *state,
+                                                       fw_action_t new_action)
+{
+    fw_action_t old_action = state->default_action;
+    if (new_action == old_action) {
+        return FILTER_ERR_OKAY;
+    }
+
+    if (old_action == FILTER_ACT_CONNECT) {
+        fw_filter_err_t err = fw_filter_remove_instances(state, true, 0);
+        assert(err == FILTER_ERR_OKAY);
+    }
+    
+    state->default_action = new_action;
+
+    return FILTER_ERR_OKAY;
+}
+
+/**
+ * Remove a filter rule.
+ * 
+ * @param state address of filter state.
+ * @param rule_id ID of rule to be deleted.
+ *
+ * @return error status.
+ */
+static fw_filter_err_t fw_filter_remove_rule(fw_filter_state_t *state,
+                                             uint16_t rule_id)
+{
+    fw_rule_t *rule = state->rules + rule_id;
+    if (rule_id >= state->rules_capacity || !rule->valid) {
+        return FILTER_ERR_INVALID_RULE_ID;
+    }
+
+    fw_action_t rule_action = rule->action;
+    if (rule_action == FILTER_ACT_CONNECT) {
+        fw_filter_err_t err = fw_filter_remove_instances(state, false, rule_id);
+        assert(err == FILTER_ERR_OKAY);
+    }
+    
+    rule->valid = false;
+
+    return FILTER_ERR_OKAY;
+}

--- a/include/lions/firewall/icmp.h
+++ b/include/lions/firewall/icmp.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <lions/firewall/protocols.h>
+
+#define FW_ICMP_OLD_DATA_LEN 8
+typedef struct icmp_req {
+    /* Type of ICMP packet to send */
+    uint8_t type;
+    /* Code of ICMP packet to sent */
+    uint8_t code;
+    /* Original header associated with ICMP packet */
+    ipv4_packet_t hdr;
+    /* First 8 bytes of data from original packet */
+    uint8_t data[FW_ICMP_OLD_DATA_LEN];
+} icmp_req_t;

--- a/include/lions/firewall/protocols.h
+++ b/include/lions/firewall/protocols.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <sddf/network/constants.h>
+
+/* ethernet types */
+#define ETH_HWTYPE 1
+#define ETH_TYPE_IP 0x0800U
+#define ETH_TYPE_ARP 0x0806U
+
+/* IP protocols */
+#define IPV4_PROTO_LEN 4
+#define IPV4_PROTO_ICMP 0x01
+#define IPV4_PROTO_TCP 0x06
+#define IPV4_PROTO_UDP 0x11
+
+/* arp types */
+#define ETHARP_OPCODE_REQUEST 1
+#define ETHARP_OPCODE_REPLY 2
+
+/* ICMP Control Types. */
+#define ICMP_ECHO_REPLY 0
+#define ICMP_DEST_UNREACHABLE 3
+#define ICMP_SRC_QUENCH 4
+#define ICMP_REDIRECT_MSG 5
+#define ICMP_ECHO_REQ 8
+#define ICMP_ROUTER_AD 9
+#define ICMP_ROUTER_SOLIT 10
+/* @kwinter: Fill out the rest of these ICMP definitions. */
+
+/* ICMP Destination Unreachable Subtypes. */
+#define ICMP_DEST_NET_UNREACHABLE 0
+#define ICMP_DEST_HOST_UNREACHABLE 1
+#define ICMP_DEST_PROTO_UNREACHABLE 2
+#define ICMP_DEST_PORT_UNREACHABLE 3
+#define ICMP_DEST_FRAG_REQ 4
+#define ICMP_SRC_ROUTE_FAIL 5
+#define ICMP_DEST_NET_UNKNOWN 6
+#define ICMP_DEST_HOST_UNKNOWN 7
+#define ICMP_SRC_HOST_ISOLATED 8
+#define ICMP_NET_ADMIN_PROHIBITED 9
+#define ICMP_HOST_ADMIN_PROHIBITED 10
+
+/* IP packet including ethernet header */
+typedef struct __attribute__((__packed__)) ipv4_packet {
+    uint8_t ethdst_addr[ETH_HWADDR_LEN];
+    uint8_t ethsrc_addr[ETH_HWADDR_LEN];
+    uint16_t type;
+    uint8_t ihl_version;
+    uint8_t tos;
+    uint16_t tot_len;
+    uint16_t id;
+    uint16_t frag_off;
+    uint8_t ttl;
+    uint8_t protocol;
+    uint16_t check;
+    uint32_t src_ip;
+    uint32_t dst_ip;
+} ipv4_packet_t;
+
+/* IP packet header */
+typedef struct __attribute__((__packed__)) ipv4hdr {
+    uint8_t ihl_version;
+    uint8_t tos;
+    uint16_t tot_len;
+    uint16_t id;
+    uint16_t frag_off;
+    uint8_t ttl;
+    uint8_t protocol;
+    uint16_t check;
+    uint32_t src_ip;
+    uint32_t dst_ip;
+} ipv4hdr_t;
+
+/* arp packet including ethernet header */
+typedef struct __attribute__((__packed__)) arp_packet {
+      uint8_t ethdst_addr[ETH_HWADDR_LEN];
+      uint8_t ethsrc_addr[ETH_HWADDR_LEN];
+      uint16_t type;
+      uint16_t hwtype;
+      uint16_t proto;
+      uint8_t hwlen;
+      uint8_t protolen;
+      uint16_t opcode;
+      uint8_t hwsrc_addr[ETH_HWADDR_LEN];
+      uint32_t ipsrc_addr;
+      uint8_t hwdst_addr[ETH_HWADDR_LEN];
+      uint32_t ipdst_addr;
+      uint8_t padding[10];
+      uint32_t crc;
+} arp_packet_t;
+
+/* arp header */
+typedef struct __attribute__((__packed__)) arphdr {
+    uint16_t hwtype;
+    uint16_t proto;
+    uint8_t hwlen;
+    uint8_t protolen;
+    uint16_t opcode;
+    uint8_t hwsrc_addr[ETH_HWADDR_LEN];
+    uint32_t ipsrc_addr;
+    uint8_t hwdst_addr[ETH_HWADDR_LEN];
+    uint32_t ipdst_addr;
+} arphdr_t;
+
+/* udp header */
+typedef struct __attribute__((__packed__)) udphdr
+{
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint16_t len;
+    uint16_t check;
+} udphdr_t;
+
+/* tcp header */
+typedef struct __attribute__((__packed__)) tcphdr
+  {
+    uint16_t src_port;
+    uint16_t dst_port;
+    uint32_t seq;
+    uint32_t ack_seq;
+    uint16_t res1:4;
+    uint16_t doff:4;
+    uint16_t fin:1;
+    uint16_t syn:1;
+    uint16_t rst:1;
+    uint16_t psh:1;
+    uint16_t ack:1;
+    uint16_t urg:1;
+    uint16_t res2:2;
+    uint16_t window;
+    uint16_t check;
+    uint16_t urg_ptr;
+} tcphdr_t;
+
+/* icmp packet including ethernet header */
+typedef struct __attribute__((__packed__)) icmp_packet
+{
+    uint8_t ethdst_addr[ETH_HWADDR_LEN];
+    uint8_t ethsrc_addr[ETH_HWADDR_LEN];
+    uint16_t eth_type;
+    uint8_t ihl_version;
+    uint8_t tos;
+    uint16_t tot_len;
+    uint16_t id;
+    uint16_t frag_off;
+    uint8_t ttl;
+    uint8_t protocol;
+    uint16_t check;
+    uint32_t src_ip;
+    uint32_t dst_ip;
+    uint8_t type;		    /* message type */
+    uint8_t code;		    /* type sub-code */
+    uint16_t checksum;
+    // 4-byte padding boundary
+    uint32_t _unused;
+    ipv4hdr_t old_ip_hdr;
+    uint64_t old_data;
+} icmp_packet_t;
+
+/**
+ * Extract offset of IP protocol header from IP packet.
+ *
+ * @param ip_pkt address of IP packet.
+ *
+ * @return offset of IP protocol header.
+ */
+static uint8_t transport_layer_offset(ipv4_packet_t *ip_pkt)
+{
+    return sizeof(struct ethernet_header) + 4 * (ip_pkt->ihl_version & 0xF);
+}

--- a/include/lions/firewall/queue.h
+++ b/include/lions/firewall/queue.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sddf/util/fence.h>
+#include <sddf/util/util.h>
+ 
+typedef struct fw_queue_indeces {
+    /* index to insert at */
+    uint64_t tail;
+    /* index to remove from */
+    uint64_t head;
+} fw_queue_indeces_t;
+
+typedef struct fw_queue {
+    /* shared indeces for queue */
+    fw_queue_indeces_t *idx;
+    /* shared data entries */
+    uintptr_t entries;
+    /* size of each data entry */
+    size_t entry_size;
+    /* capacity of the queue. Must be a power of 2 */
+    size_t capacity;
+} fw_queue_t;
+
+/**
+ * Get the number of valid entries in the queue.
+ *
+ * @param queue queue.
+ *
+ * @return number of valid entries.
+ */
+static inline uint16_t fw_queue_length(fw_queue_t *queue)
+{
+    return queue->idx->tail - queue->idx->head;
+}
+
+/**
+ * Check if a queue is empty.
+ *
+ * @param queue queue.
+ *
+ * @return true indicates the queue is empty, false otherwise.
+ */
+static inline bool fw_queue_empty(fw_queue_t *queue)
+{
+    return queue->idx->tail - queue->idx->head == 0;
+}
+
+/**
+ * Check if a queue is full.
+ *
+ * @param queue queue.
+ *
+ * @return true indicates the queue is full, false otherwise.
+ */
+static inline bool fw_queue_full(fw_queue_t *queue)
+{
+    return queue->idx->tail - queue->idx->head == queue->capacity;
+}
+
+/**
+ * Enqueue an element into a queue.
+ *
+ * @param queue queue to enqueue into.
+ * @param entry element to be enqueued.
+ *
+ * @return -1 when queue is full, 0 on success.
+ */
+static inline int fw_enqueue(fw_queue_t *queue,
+                             void *entry)
+{
+    if (fw_queue_full(queue)) {
+        return -1;
+    }
+    
+    size_t offset = (queue->idx->tail % queue->capacity) * queue->entry_size;
+    uintptr_t dest = queue->entries + offset;
+    memcpy((void *)dest, entry, queue->entry_size);
+
+#ifdef CONFIG_ENABLE_SMP_SUPPORT
+     THREAD_MEMORY_RELEASE();
+#endif
+    queue->idx->tail++;
+
+    return 0;
+}
+
+/**
+ * Dequeue an element from a queue.
+ *
+ * @param queue queue to dequeue from.
+ * @param entry address to copy dequeued entry to.
+ *
+ * @return -1 when queue is empty, 0 on success.
+ */
+static inline int fw_dequeue(fw_queue_t *queue,
+                             void *entry)
+{
+    if (fw_queue_empty(queue)) {
+        return -1;
+    }
+
+    size_t offset = (queue->idx->head % queue->capacity) * queue->entry_size;
+    uintptr_t src = queue->entries + offset;
+    memcpy(entry, (void *)src, queue->entry_size);
+
+#ifdef CONFIG_ENABLE_SMP_SUPPORT
+    THREAD_MEMORY_RELEASE();
+#endif
+    queue->idx->head++;
+
+    return 0;
+}
+
+/**
+ * Initialise the shared queue.
+ *
+ * @param queue address of queue to initialise.
+ * @param data adress of shared data.
+ * @param entry_size size of queue entries.
+ * @param capacity capacity of the queue.
+ */
+static inline void fw_queue_init(fw_queue_t *queue,
+                                 void *data,
+                                 size_t entry_size,
+                                 size_t capacity)
+{
+    queue->idx = (fw_queue_indeces_t *)data;
+    queue->entries = (uintptr_t)data + sizeof(fw_queue_indeces_t);
+    queue->entry_size = entry_size;
+    queue->capacity = capacity;
+}

--- a/include/lions/firewall/routing.h
+++ b/include/lions/firewall/routing.h
@@ -1,0 +1,501 @@
+/*
+ * Copyright 2025, UNSW
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <sddf/network/queue.h>
+#include <lions/firewall/array_functions.h>
+#include <lions/firewall/common.h>
+#include <lions/firewall/queue.h>
+
+/* IP of no next hop */
+#define FW_ROUTING_NONEXTHOP 0
+
+/* maximum number of recursive calls that fw_routing_find_route makes to resolve
+a route for an ip address */
+#define FW_ROUTING_MAX_RECURSION 3
+
+typedef enum {
+    /* no error */
+    ROUTING_ERR_OKAY = 0,
+    /* data structure is full */
+	ROUTING_ERR_FULL,
+    /* duplicate entry exists */
+	ROUTING_ERR_DUPLICATE,
+    /* entry clashes with existing entry */
+    ROUTING_ERR_CLASH,
+    /* node ID does not point to a valid node */
+    ROUTING_ERR_INVALID_ID,
+    /* route is invalid */
+    ROUTING_ERR_INVALID_ROUTE
+} fw_routing_err_t;
+
+static const char *fw_routing_err_str[] = {
+    "Ok.",
+    "Out of memory error.",
+    "Duplicate entry.",
+    "Clashing entry.",
+    "Invalid child node.",
+    "Invalid route ID.",
+    "Invalid route values."
+};
+
+/* routing interfaces */
+typedef enum {
+    /* no interface */
+    ROUTING_OUT_NONE = 0,
+    /* transmit out NIC */
+    ROUTING_OUT_EXTERNAL,
+    /* transmit internally within the system */
+	ROUTING_OUT_SELF
+} fw_routing_interfaces_t;
+
+/* PP call parameters for webserver to call router and update routing table */
+#define FW_ADD_ROUTE 0
+#define FW_DEL_ROUTE 1
+
+typedef enum {
+    ROUTER_ARG_ROUTE_ID = 0,
+    ROUTER_ARG_IP,
+    ROUTER_ARG_SUBNET,
+    ROUTER_ARG_NEXT_HOP
+} fw_router_args_t;
+
+typedef enum {
+    ROUTER_RET_ERR = 0
+} fw_router_ret_args_t;
+
+typedef struct routing_entry {
+    /* ip address of destination subnet */
+    uint32_t ip;
+    /* number of bits in subnet mask */
+    uint8_t subnet;
+    /* interface subnet traffic should be transmitted through */
+    uint8_t interface;
+    /* ip address of next hop */
+    uint32_t next_hop;
+} fw_routing_entry_t;
+
+typedef struct routing_table {
+    /* capacity of table */
+    uint16_t capacity;
+    /* number of valid entries in table */
+    uint16_t size;
+    /* routing table entries stored consecutively */
+    fw_routing_entry_t entries[];
+} fw_routing_table_t;
+
+/* packet waiting node used to store outgoing packets before MAC address has
+been resolved */
+typedef struct pkt_waiting_node {
+    /* next packet waiting node */
+    uint16_t next;
+    /* previous packet waiting node, only maintained for nodes in use */
+    uint16_t prev;
+    /* child packet waiting node, nodes destined for same ip */
+    uint16_t child;
+    /* number of child nodes, only maintained for root node */
+    uint16_t num_children;
+    /* destination ip for this packet and child packets, only maintained for
+    root node */
+    uint32_t ip;
+    /* buffer of outgoing packet */
+    net_buff_desc_t buffer;
+} pkt_waiting_node_t;
+
+typedef struct pkts_waiting {
+    /* address of packet node table */
+    pkt_waiting_node_t *packets;
+    /* capacity of packet node table */
+    uint16_t capacity;
+    /* number of nodes in use */
+    uint16_t size;
+    /* number of root nodes */
+    uint16_t length;
+    /* head of root nodes */
+    uint16_t head;
+    /* tail of root nodes */
+    uint16_t tail;
+    /* head of free nodes */
+    uint16_t free;
+} pkts_waiting_t;
+
+/**
+ * Initialise packet waiting structure.
+ *
+ * @param pkts_waiting address of packets waiting structure.
+ * @param packets virtual address of packets.
+ * @param capacity number of available packet waiting nodes.
+ */
+static void pkt_waiting_init(pkts_waiting_t *pkts_waiting,
+                      void *packets,
+                      int16_t capacity)
+{
+    pkts_waiting->packets = (pkt_waiting_node_t *)packets;
+    pkts_waiting->capacity = capacity;
+    for (uint16_t i = 0; i < pkts_waiting->capacity; i++) {
+        pkt_waiting_node_t *node = pkts_waiting->packets + i;
+        /* Free list only maintains next pointers */
+        node->next = i + 1;
+    }
+}
+
+/**
+ * Check if the packet waiting queue is full.
+ *
+ * @param pkts_waiting address of packets waiting structure.
+ *
+ * @return whether packet waiting queue is full.
+ */
+static bool pkt_waiting_full(pkts_waiting_t *pkts_waiting)
+{
+    return pkts_waiting->size == pkts_waiting->capacity;
+}
+
+/**
+ * Find matching ip packet waiting node in packet waiting list.
+ *
+ * @param pkts_waiting address of packets waiting structure.
+ * @param ip ip adress to match with.
+ *
+ * @return address of matching packet waiting root node or NULL if no match.
+ */
+static pkt_waiting_node_t *pkt_waiting_find_node(pkts_waiting_t *pkts_waiting,
+                                          uint32_t ip)
+{
+    pkt_waiting_node_t *node = pkts_waiting->packets + pkts_waiting->head;
+    for (uint16_t i = 0; i < pkts_waiting->length; i++) {
+        if (node->ip == ip) {
+            return node;
+        }
+        node = pkts_waiting->packets + node->next;
+    }
+
+    return NULL;
+}
+
+/**
+ * Return the next child node, assumes child node is valid!
+ *
+ * @param pkts_waiting address of packets waiting structure.
+ * @param node parent node.
+ *
+ * @return address of child node.
+ */
+static pkt_waiting_node_t *pkts_waiting_next_child(pkts_waiting_t *pkts_waiting,
+                                            pkt_waiting_node_t *node)
+{
+    return pkts_waiting->packets + node->child;
+}
+
+/**
+ * Add a child node to a root waiting node. Node passed must be a root node!
+ *
+ * @param pkts_waiting address of packets waiting structure.
+ * @param root root node.
+ * @param buffer buffer holding outgoing packet to be stored in new node.
+ *
+ * @return error status of operation.
+ */
+static fw_routing_err_t pkt_waiting_push_child(pkts_waiting_t *pkts_waiting,
+                                        pkt_waiting_node_t *root,
+                                        net_buff_desc_t buffer)
+{
+    if (pkt_waiting_full(pkts_waiting)) {
+        return ROUTING_ERR_FULL;
+    }
+
+    uint16_t new_idx = pkts_waiting->free;
+    pkt_waiting_node_t *new_node = pkts_waiting->packets + new_idx;
+
+    /* Update values */
+    new_node->buffer = buffer;
+
+    /* Update pointers */
+    pkts_waiting->free = new_node->next;
+    pkt_waiting_node_t *last_child = root;
+    for (uint16_t i = 0; i < root->num_children; i++) {
+        last_child = pkts_waiting_next_child(pkts_waiting, last_child);
+    }
+    last_child->child = new_idx;
+
+    /* Update counts */
+    root->num_children++;
+    pkts_waiting->size++;
+
+    return ROUTING_ERR_OKAY;
+}
+
+/**
+ * Add a new root node to IP packet list. Assumes no valid root node for IP.
+ *
+ * @param pkts_waiting address of packets waiting structure.
+ * @param ip IP address of outgoing packet stored in new node.
+ * @param buffer buffer holding outgoing packet to be stored in new node.
+ *
+ * @return error status of operation.
+ */
+static fw_routing_err_t pkt_waiting_push(pkts_waiting_t *pkts_waiting,
+                                  uint32_t ip,
+                                  net_buff_desc_t buffer)
+{
+    if (pkt_waiting_full(pkts_waiting)) {
+        return ROUTING_ERR_FULL;
+    }
+
+    uint16_t new_idx = pkts_waiting->free;
+    pkt_waiting_node_t *new_node = pkts_waiting->packets + new_idx;
+
+    /* Update values */
+    new_node->num_children = 0;
+    new_node->ip = ip;
+    new_node->buffer = buffer;
+
+    /* Update pointers */
+    pkts_waiting->free = new_node->next;
+    /* If this is not the first node */
+    if (pkts_waiting->length) {
+        uint16_t head_idx = pkts_waiting->head;
+        pkt_waiting_node_t *head_node = pkts_waiting->packets + head_idx;
+
+        new_node->next = head_idx;
+        head_node->prev = new_idx;
+    } else {
+        pkts_waiting->tail = new_idx;
+    }
+    pkts_waiting->head = new_idx;
+
+    /* Update counts */
+    pkts_waiting->length++;
+    pkts_waiting->size++;
+    
+    return ROUTING_ERR_OKAY;
+}
+
+/**
+ * Free a node and all its children. Must pass a root node!
+ *
+ * @param pkts_waiting address of packets waiting structure.
+ * @param root root node to free.
+ *
+ * @return error status of operation.
+ */
+static fw_routing_err_t pkts_waiting_free_parent(pkts_waiting_t *pkts_waiting,
+                                          pkt_waiting_node_t *root)
+{
+    /* First free children */
+    uint16_t child_idx = root->child;
+    pkt_waiting_node_t *child_node = pkts_waiting_next_child(pkts_waiting, root);
+    for (uint16_t i = 0; i < root->num_children; i++) {
+
+        /* Add to free list */
+        child_node->next = pkts_waiting->free;
+        pkts_waiting->free = child_idx;
+        pkts_waiting->size--;
+
+        /* Possibly free next child */
+        child_idx = child_node->child;
+        child_node = pkts_waiting_next_child(pkts_waiting, child_node);
+    }
+
+    /* Now free parent */
+    uint16_t root_idx = (uint16_t)(root - pkts_waiting->packets);
+    if (root_idx == pkts_waiting->head) {
+        /* Root node is head */
+        pkts_waiting->head = root->next;
+    } else {
+        pkt_waiting_node_t *prev_node = pkts_waiting->packets + root->prev;
+        prev_node->next = root->next;
+    }
+
+    if (root_idx == pkts_waiting->tail) {
+        /* Root node is tail */
+        pkts_waiting->tail = root->prev;
+    } else {
+        pkt_waiting_node_t *next_node = pkts_waiting->packets + root->next;
+        next_node->prev = root->prev;
+    }
+
+    root->next = pkts_waiting->free;
+    pkts_waiting->free = root_idx;
+    pkts_waiting->length--;
+    pkts_waiting->size--;
+
+    return ROUTING_ERR_OKAY;
+}
+
+/**
+ * Find next hop for destination IP. Maximum recursion limit to prevent infinite
+ * looping.
+ *
+ * @param table address of routing table.
+ * @param ip IP address to find route to.
+ * @param next_hop address to store IP of next hop.
+ * @param interface interface traffic should be routed out.
+ * @param num_calls number of times fw_routing_find_route has been called
+ * recursively. Pass 0 for maximum number of recursive calls.
+ *
+ * @return error status of operation.
+ */
+static fw_routing_err_t fw_routing_find_route(fw_routing_table_t *table,
+                                      uint32_t ip,
+                                      uint32_t *next_hop,
+                                      fw_routing_interfaces_t *interface,
+                                      uint8_t num_calls)
+{
+    fw_routing_entry_t *match = NULL;
+    for (uint16_t i = 0; i < table->size; i++) {
+        fw_routing_entry_t *entry = table->entries + i;
+
+        /* ip is part of subnet */
+        if ((subnet_mask(entry->subnet) & ip) == entry->ip) {
+
+            /* Current match is stronger */
+            if (match != NULL && match->subnet > entry->subnet) {
+                continue;
+            }
+
+            match = entry;
+        }
+    }
+
+    if (match == NULL) {
+        /* No route found */
+        *interface = ROUTING_OUT_NONE;
+    } else if (match->interface == ROUTING_OUT_SELF) {
+        /* Route internally */
+        *interface = ROUTING_OUT_SELF;
+    } else if (match->interface == ROUTING_OUT_EXTERNAL &&
+               match->next_hop == FW_ROUTING_NONEXTHOP) {
+        *next_hop = ip;
+        *interface = ROUTING_OUT_EXTERNAL;
+    } else if (match->interface == ROUTING_OUT_EXTERNAL &&
+               match->next_hop != FW_ROUTING_NONEXTHOP) {
+        num_calls ++;
+        if (num_calls == FW_ROUTING_MAX_RECURSION) {
+            /* Find route has hit recursive call limit, ip unreachable. */
+            *interface = ROUTING_OUT_NONE;
+            return ROUTING_ERR_OKAY;
+        }
+        fw_routing_err_t err = fw_routing_find_route(table,
+                                                 match->next_hop,
+                                                    next_hop,
+                                                    interface,
+                                                    num_calls);
+        return err;
+    }
+
+    return ROUTING_ERR_OKAY;
+}
+
+/**
+ * Add a route to the routing table.
+ *
+ * @param table address of routing table.
+ * @param interface interface route should be routed out.
+ * @param ip IP address of route.
+ * @param subnet subnet bits of route.
+ * @param next_hop next hop IP adress of route.
+ *
+ * @return error status of operation.
+ */
+static fw_routing_err_t fw_routing_table_add_route(fw_routing_table_t *table,
+                                                   fw_routing_interfaces_t interface,
+                                                   uint32_t ip,
+                                                   uint8_t subnet,
+                                                   uint32_t next_hop)
+{
+    /* Default routes must specify a next hop! */
+    if ((subnet == 0) && (next_hop == FW_ROUTING_NONEXTHOP)) {
+        return ROUTING_ERR_INVALID_ROUTE;
+    } else if (table->size >= table->capacity) {
+        return ROUTING_ERR_FULL;
+    }
+
+    for (uint16_t i = 0; i < table->size; i++) {
+        fw_routing_entry_t *entry = table->entries + i;
+
+        /* One rule applies to a larger subnet than the other */
+        if (subnet != entry->subnet) {
+            continue;
+        }
+
+        /* Rules apply to different subnets */
+        if ((subnet_mask(subnet) & ip) != entry->ip) {
+            continue;
+        }
+
+        /* There is a clash! */
+        if ((interface == entry->interface) && (next_hop == entry->next_hop)) {
+            return ROUTING_ERR_DUPLICATE;
+        } else {
+            return ROUTING_ERR_CLASH;
+        }
+    }
+
+    fw_routing_entry_t *empty_slot = table->entries + table->size;
+    empty_slot->interface = interface;
+    empty_slot->ip = subnet_mask(subnet) & ip;
+    empty_slot->subnet = subnet;
+    empty_slot->next_hop = next_hop;
+    table->size++;
+
+    return ROUTING_ERR_OKAY;
+}
+
+/**
+ * Remove a route from the routing table.
+ *
+ * @param table address of routing table.
+ * @param route_id ID of route to remove.
+ *
+ * @return error status of operation.
+ */
+static fw_routing_err_t fw_routing_table_remove_route(fw_routing_table_t *table,
+                                                      uint16_t route_id)
+{
+    if (route_id >= table->size) {
+        return ROUTING_ERR_INVALID_ID;
+    }
+
+    /* Shift everything left to delete this item */
+    generic_array_shift(table->entries, sizeof(fw_routing_entry_t),
+                        table->capacity,
+                        route_id);
+    table->size--;
+    return ROUTING_ERR_OKAY;
+}
+
+/**
+ * Initialise the routing table. Adds entry for external interface based on
+ * external subnet.
+ *
+ * @param table address of routing table.
+ * @param table_vaddr address of routing entries.
+ * @param capacity capacity of routing table.
+ * @param extern_ip IP address of external interface.
+ * @param extern_subnet subnet bits of external interface.
+ */
+static void fw_routing_table_init(fw_routing_table_t **table,
+                                  void *table_vaddr, 
+                                  uint16_t capacity,
+                                  uint32_t extern_ip,
+                                  uint8_t extern_subnet)
+{
+    *table = (fw_routing_table_t *)table_vaddr;
+    (*table)->capacity = capacity;
+    (*table)->size = 0;
+
+    /* Add a route for external network */
+    fw_routing_err_t err = fw_routing_table_add_route(*table,
+                                           ROUTING_OUT_EXTERNAL,
+                                                  extern_ip, 
+                                              extern_subnet,
+                                            FW_ROUTING_NONEXTHOP);
+    assert(err == ROUTING_ERR_OKAY);
+}


### PR DESCRIPTION
This PR adds the LionsOS Firewall example to main. Along with this PR, over the next few days I will additionally be adding:
- Documentation to the LionsOS website
- Issue and missing feature tracking to git issues

Currently, the firewall offers a collection of rudimentary functionalities, summarised below:

## General
- Currently supports 2 network interfaces (external and internal)
- Traffic can from one interface to the other, as well from the internal interface to the webserver
- Traffic types supported:
    - ARP: Responses for the firewall, requests for outgoing traffic
    - ICMP: forwarding and transmitting `destination unreachable` packets
    - UDP & TCP: forwarding
- Most components (with the exception of the webserver and ICMP module) are duplicated per network interface 

## ARP
- The ARP requester component sends out ARP requests for IPs the system wishes to forward to
    - If a reply is received an ARP entry is inserted into a cache which is reused by the system until a periodic flush occurs
    - If a reply is not received after a configurable time interval (default 1 second), a duplicate request is send (up to 5 re-tries)

## Filters
- Filter components decide whether or not traffic is permitted to be forwarded through the firewall. Every packet received is directed by the virtualiser to the relevant filter (currently ICMP, UDP and TCP).
- Each packet is checked against the current rules table. If a match is not found the default rule is used. Currently the following options for actions are:
    - Allow
    - Drop
    - Connect (which allows both the packet *and* return traffic, requiring shared state between the filters)
- Rules can be updated at runtime using the webserver

## Routing
- If traffic is permitted by a filter, it is passed to the routing component which is responsible for updating the destination MAC address and transmitting the packet out the NIC.
- First, the routing table will be consulted to determine which NIC the packet should be transmitted through (currently only 1 possible NIC or internally to the webserver). 
- Routing table routes can be updated using the Micropython webserver UI.
- Second, the ARP table is checked for an existing entry for the destination IP. If one is found, the packet is updated and transmitted. If there is no match, the packet will be temporarily stored and the ARP requester will contacted to request the MAC. If the request comes back successfully, the packet will be updated and transmitted, else the packet will be dropped and the ICMP module will be notified.

## ICMP Module
- The ICMP module handles the sending of `destination unreachable` packets to senders if the firewall cannot find a route to the destination.
- Both routing components have a connection to the module.
- In the future, the module will be expanded to handle a larger class of ICMP packets.

## Webserver
- The Micropython webserver provides a web UI accessible from the internal network which allows filter rules and routing tables routes to be updated at runtime.

## Building
- Due to the high complexity of the system and the many connections between components, building the system without the use of additional python scripting is particularly challenging and easy to get wrong. Thus the firewall utilises a collection of newly developed scripts and techniques which automate much of this process.
- This can mostly be seen in the `sdfgen_helper.py` script which is automatically invoked with `make` and generates additional python modules which are used in `metaprogram.py`.
- These scripts and techniques will be expanded upon in the LionsOS docs.

## Performance
Performance is not yet a major focus of this project, but as a milestone I tested ping latency in both directions:

External --> Internal
PING 192.168.1.2 (192.168.1.2) 56(84) bytes of data.
64 bytes from 192.168.1.2: icmp_seq=1 ttl=63 time=0.967 ms
64 bytes from 192.168.1.2: icmp_seq=2 ttl=63 time=0.855 ms
64 bytes from 192.168.1.2: icmp_seq=3 ttl=63 time=1.04 ms
64 bytes from 192.168.1.2: icmp_seq=4 ttl=63 time=1.05 ms
64 bytes from 192.168.1.2: icmp_seq=5 ttl=63 time=0.771 ms
64 bytes from 192.168.1.2: icmp_seq=6 ttl=63 time=0.460 ms
64 bytes from 192.168.1.2: icmp_seq=7 ttl=63 time=0.986 ms
64 bytes from 192.168.1.2: icmp_seq=8 ttl=63 time=1.21 ms
64 bytes from 192.168.1.2: icmp_seq=9 ttl=63 time=1.16 ms
64 bytes from 192.168.1.2: icmp_seq=10 ttl=63 time=0.866 ms
64 bytes from 192.168.1.2: icmp_seq=11 ttl=63 time=0.774 ms
64 bytes from 192.168.1.2: icmp_seq=12 ttl=63 time=0.654 ms

Internal --> External
PING 172.16.0.2 (172.16.0.2) 56(84) bytes of data.
64 bytes from 172.16.0.2: icmp_seq=1 ttl=63 time=0.484 ms
64 bytes from 172.16.0.2: icmp_seq=2 ttl=63 time=0.851 ms
64 bytes from 172.16.0.2: icmp_seq=3 ttl=63 time=0.991 ms
64 bytes from 172.16.0.2: icmp_seq=4 ttl=63 time=0.990 ms
64 bytes from 172.16.0.2: icmp_seq=5 ttl=63 time=0.747 ms
64 bytes from 172.16.0.2: icmp_seq=6 ttl=63 time=0.578 ms
64 bytes from 172.16.0.2: icmp_seq=7 ttl=63 time=0.806 ms
64 bytes from 172.16.0.2: icmp_seq=8 ttl=63 time=1.07 ms
64 bytes from 172.16.0.2: icmp_seq=9 ttl=63 time=0.780 ms
64 bytes from 172.16.0.2: icmp_seq=10 ttl=63 time=0.740 ms
64 bytes from 172.16.0.2: icmp_seq=11 ttl=63 time=0.715 ms
64 bytes from 172.16.0.2: icmp_seq=12 ttl=63 time=0.777 ms

Note there is not currently a Microkit config for `benchmark` or `release` for the `iotgate`, so these tests were performed in `debug` with debug printing turned off.