### PR TITLE
Fix parsing of memory region entry size lines

### DIFF
--- a/examples/firewall/meta.py
+++ b/examples/firewall/meta.py
@@ -762,7 +762,7 @@ if __name__ == '__main__':
         if entry_size == 0:
             # Extract lines that hold the value of the size variable. NOTE: we
             # assume the value is < UINT32_MAX
-            entry_size_lines = subprocess.run(["grep", "-A", "1", f"<{mem_region.c_name}>"],
+            entry_size_lines = subprocess.run(["grep", "-A", "1", "-E", f"^[0-9a-f]+ <{mem_region.c_name}>"],
                                               input=objdump_process.stdout,
                                               stdout=subprocess.PIPE,
                                               stderr=subprocess.PIPE,


### PR DESCRIPTION
Fixes errors such as:

```
Traceback (most recent call last):
  File "/home/simon/lionsos/examples/firewall/meta.py", line 783, in <module>
    entry_size = int(size_hex_string, 16)
ValueError: invalid literal for int() with base 16: '  2002c0: d0000020     \\tadrp\\tx0, 0x206000 <fw_rule_size>\\n  2002c4: 9113e800     \\tadd\\tx0, x0, #0x4fa\\n  2002c8: d0000021     \\tadrp\\tx1, 0x206000 <fw_rule_size>\\n  2002cc: 910ffc21     \
```