### PR TITLE
Refactor common things out of Makefiles

### DIFF
--- a/boards/common
+++ b/boards/common
@@ -1,0 +1,52 @@
+#
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+
+# Board-related common defines.
+BOARD_DIR := $(MICROKIT_SDK)/board/$(MICROKIT_BOARD)/$(MICROKIT_CONFIG)
+
+# Sanity checking:
+# The board name must be supported for the project (i.e., in the
+# SUPPORTED_BOARDS list); must have a corresponding board
+# directory in the microkit SDK, and must have a makefile snippet
+# in ${LIONSOS}/boards
+
+ifeq ($(findstring $(strip ${MICROKIT_BOARD}),${SUPPORTED_BOARDS}),)
+  $(error ${MICROKIT_BOARD} not (yet) supported for this project)
+endif
+
+ifeq ($(wildcard ${BOARD_DIR}),)
+  $(error ${MICROKIT_BOARD} not supported by ${MICROKIT_SDK})
+endif
+
+ifeq ($(wildcard ${LIONSOS}/boards/${MICROKIT_BOARD}),)
+  $(error No Make snippet in ${LIONSOS}/boards for ${MICROKIT_BAORD})
+endif
+
+include ${LIONSOS}/boards/${MICROKIT_BOARD}
+
+SDDF := $(LIONSOS)/dep/sddf
+MICROKIT_TOOL ?= $(MICROKIT_SDK)/bin/microkit
+
+DTS := $(SDDF)/dts/$(MICROKIT_BOARD).dts
+DTB := $(MICROKIT_BOARD).dtb
+DTC := dtc
+
+PYTHON ?= python3
+
+LDFLAGS := -L$(BOARD_DIR)/lib -L$(MUSL)/lib
+
+# Common Make rules
+%.elf: %.o
+	${LD} ${LDFLAGS} -o $@ $< ${LIBS}
+
+$(DTB): $(DTS)
+	$(DTC) -q -I dts -O dtb $(DTS) > $(DTB)
+
+# Some boards have more than one ethernet port.  The first is always called
+# $(ETH_DRIV); projects that expect only one use eth_driver.elf
+
+eth_driver.elf: ${ETH_DRIV}
+	cp $< $@

--- a/boards/imx8mp_iotgate
+++ b/boards/imx8mp_iotgate
@@ -1,0 +1,15 @@
+#
+# Copyright 2025 UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Definitions for the IOTgate --- an imx8mp based board.
+# with Two ethernet interfaces
+ETH_DRIV_DIR := imx
+ETH_DRIV := eth_driver_imx.elf
+ETH_DRIV_DIR1 := dwmac-5.10a
+ETH_DRIV_1 := eth_driver_dwmac-5.10a.elf
+SERIAL_DRIV_DIR := imx
+TIMER_DRV_DIR := imx
+CPU := cortex-a53
+BLK_DRIV_DIR := mmc/imx

--- a/boards/maaxboard
+++ b/boards/maaxboard
@@ -1,0 +1,13 @@
+#
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# MAAXboard definitions.
+# 
+BLK_DRIV_DIR := mmc/imx
+SERIAL_DRIV_DIR := imx
+TIMER_DRIV_DIR := imx
+ETH_DRIV_DIR := imx
+ETH_DRIV := eth_driver_imx.elf
+CPU := cortex-a53

--- a/boards/odroidc4
+++ b/boards/odroidc4
@@ -1,0 +1,15 @@
+#
+# Copyright 2025 UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Definitions for the Odroid C4
+ETH_DRIV_DIR := meson
+ETH_DRIV := eth_driver_meson.elf
+SERIAL_DRIV_DIR := meson
+TIMER_DRIV_DIR := meson
+I2C_DRIV_DIR := meson
+
+CPU := cortex-a55
+
+

--- a/boards/qemu_virt_aarch64
+++ b/boards/qemu_virt_aarch64
@@ -1,0 +1,15 @@
+#
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Definitions for 64-bit ARM QEMU
+# 
+BLK_DRIV_DIR := virtio
+SERIAL_DRIV_DIR := arm
+TIMER_DRIV_DIR := arm
+ETH_DRIV_DIR := virtio
+ETH_DRIV := eth_driver_virtio.elf
+
+CPU := cortex-a53
+QEMU := qemu-system-aarch64

--- a/examples/firewall/Makefile
+++ b/examples/firewall/Makefile
@@ -21,7 +21,7 @@ nproc:= $(shell sh -c "if test -f /proc/cpuinfo; then grep processor /proc/cpuin
 
 all: ${IMAGE_FILE}
 
-qemu ${IMAGE_FILE}: ${BUILD_DIR}/Makefile FORCE
+clean clobber qemu ${IMAGE_FILE}: ${BUILD_DIR}/Makefile FORCE
 	${MAKE} -C ${BUILD_DIR} MICROKIT_SDK=${MICROKIT_SDK} $(notdir $@)
 
 ${BUILD_DIR}/Makefile: firewall.mk
@@ -29,3 +29,4 @@ ${BUILD_DIR}/Makefile: firewall.mk
 	cp firewall.mk $@
 
 FORCE:
+.PHONY: clean clobber

--- a/toolchain/clang
+++ b/toolchain/clang
@@ -1,0 +1,53 @@
+#
+# Copyright 2025, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Common definitions for LLVM/Clang
+
+CC := clang
+LD := ld.lld
+RANLIB := llvm-ranlib
+AR := llvm-ar
+OBJCOPY := llvm-objcopy
+OBJDUMP := llvm-objdump
+
+ifndef BOARD_DIR
+$(error BOARD_DIR not defined)
+endif
+
+ARCH := $(shell sed -n 's/#define *CONFIG_SEL4_ARCH  *\([^ ]*\).*$$/\1/p'  $(BOARD_DIR)/include/kernel/gen_config.h)
+
+ifndef CPU
+$(error CPU is undefined: is should be in the board file)
+endif
+
+ifeq ($(ARCH),aarch64)
+	CFLAGS_ARCH := -mcpu=$(CPU)
+	TARGET := aarch64-none-elf
+else ifeq ($(ARCH),riscv64)
+	CFLAGS_ARCH := -march=rv64imafdc
+	TARGET := riscv64-none-elf
+else
+$(error Unsupported ARCH given)
+endif
+
+CFLAGS_ARCH += -target $(TARGET)
+
+ifdef CPU
+ CFLAGS_ARCH += \
+	-mcpu=$(CPU) \
+	-mtune=$(CPU)
+endif
+
+# These are the basic flags;
+# augment with project-specific ones.
+CFLAGS :=  \
+	-mstrict-align \
+	-ffreestanding \
+	-O2 \
+	-g3 \
+	-Wall \
+	-DBOARD_$(MICROKIT_BOARD) \
+	-I$(BOARD_DIR)/include \
+	$(CFLAGS_ARCH)


### PR DESCRIPTION
To ease adding new boards to projects, abstract out all the common bits into separate files.

Do the same for the toolchain bits.

I'm not sure whether the board descriptions should be here or in sDDF.