### PR TITLE
nix: add gptfdisk as a dependency so the GPT partitions build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,7 @@
                 qemu
                 gnumake
                 dosfstools
+                gptfdisk
                 curl
                 which
                 unzip


### PR DESCRIPTION
This is because the scripts changed behaviour to default to GPT over MBR (somewhat) recently.