### PR TITLE
Revert decrease in mp event hook delay period

### DIFF
--- a/components/micropython/mpconfigport.h
+++ b/components/micropython/mpconfigport.h
@@ -113,7 +113,7 @@ typedef long mp_off_t;
 #define MP_STATE_PORT MP_STATE_VM
 
 void mp_hal_delay_us(mp_uint_t delay);
-#define MICROPY_EVENT_POLL_HOOK do { mp_hal_delay_us(1); } while (0);
+#define MICROPY_EVENT_POLL_HOOK do { mp_hal_delay_us(500); } while (0);
 
 typedef uint32_t sys_prot_t;
 
@@ -123,7 +123,7 @@ typedef uint32_t sys_prot_t;
 #define MICROPY_VM_HOOK_INIT static uint vm_hook_divisor = MICROPY_VM_HOOK_COUNT;
 #define MICROPY_VM_HOOK_POLL if (microkit_cothread_my_handle() && --vm_hook_divisor == 0) { \
         vm_hook_divisor = MICROPY_VM_HOOK_COUNT; \
-        mp_hal_delay_us(1); \
+        mp_hal_delay_us(500); \
 }
 #define MICROPY_VM_HOOK_LOOP MICROPY_VM_HOOK_POLL
 #define MICROPY_VM_HOOK_RETURN MICROPY_VM_HOOK_POLL


### PR DESCRIPTION
Although decreasing the Micropython event hook delay period did not have an impact of the webserver example, it does seem to effect the firewall's Microdot webserver. Not quite sure why, but for the moment its best to revert this change.