### PR TITLE
Fix ARP requester and router transmitting with the wrong IP/MAC

### DIFF
--- a/examples/firewall/arp/arp_responder.c
+++ b/examples/firewall/arp/arp_responder.c
@@ -104,7 +104,6 @@ static void receive(void)
                 }
             }
 
-            buffer.len = 0;
             err = net_enqueue_free(&rx_queue, buffer);
             assert(!err);
             returned = true;

--- a/examples/firewall/filters/icmp_filter.c
+++ b/examples/firewall/filters/icmp_filter.c
@@ -55,7 +55,7 @@ static void filter(void)
                 action = filter_state.default_action;
                 if (FW_DEBUG_OUTPUT) {
                     sddf_printf("%sICMP filter found no match, performing default action %s: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.webserver.interface], fw_filter_action_str[action],
+                        fw_frmt_str[filter_config.interface], fw_filter_action_str[action],
                         ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
                         ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
                 }
@@ -68,14 +68,14 @@ static void filter(void)
 
                 if ((fw_err == FILTER_ERR_OKAY || fw_err == FILTER_ERR_DUPLICATE) && FW_DEBUG_OUTPUT) {
                     sddf_printf("%sICMP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        fw_frmt_str[filter_config.interface], rule_id,
                         ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
                         ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
                 }
 
                 if (fw_err == FILTER_ERR_FULL) {
                     sddf_printf("%sICMP FILTER LOG: could not establish connection for rule %u or default action %u: (ip %s, port %u) -> (ip %s, port %u): %s\n",
-                        fw_frmt_str[filter_config.webserver.interface],
+                        fw_frmt_str[filter_config.interface],
                         rule_id, default_action, ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
                         ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT, fw_filter_err_str[fw_err]);
                 }
@@ -94,12 +94,12 @@ static void filter(void)
                 if (FW_DEBUG_OUTPUT) {
                     if (action == FILTER_ACT_ALLOW || action == FILTER_ACT_CONNECT) {
                         sddf_printf("%sICMP filter transmitting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            fw_frmt_str[filter_config.interface], rule_id,
                             ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
                             ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
                     } else if (action == FILTER_ACT_ESTABLISHED) {
                         sddf_printf("%sICMP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            fw_frmt_str[filter_config.interface], rule_id,
                             ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
                             ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
                     }
@@ -112,7 +112,7 @@ static void filter(void)
 
                 if (FW_DEBUG_OUTPUT) {
                     sddf_printf("%sICMP filter dropping via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        fw_frmt_str[filter_config.interface], rule_id,
                         ipaddr_to_string(icmp_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
                         ipaddr_to_string(icmp_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
                 }
@@ -145,7 +145,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
         if (FW_DEBUG_OUTPUT) {
             sddf_printf("%sICMP filter changing default action from %u to %u\n",
-                fw_frmt_str[filter_config.webserver.interface], filter_state.default_action, action);
+                fw_frmt_str[filter_config.interface], filter_state.default_action, action);
         }
 
         fw_filter_err_t err = fw_filter_update_default_action(&filter_state, action);
@@ -166,7 +166,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
         if (FW_DEBUG_OUTPUT) {
             sddf_printf("%sICMP filter create rule %u: (ip %s, mask %u, port %u, any_port %u) - (%s) -> (ip %s, mask %u, port %u, any_port %u): %s\n",
-                fw_frmt_str[filter_config.webserver.interface], rule_id,
+                fw_frmt_str[filter_config.interface], rule_id,
                 ipaddr_to_string(src_ip, ip_addr_buf0), src_subnet, ICMP_FILTER_DUMMY_PORT, false, fw_filter_action_str[action],
                 ipaddr_to_string(dst_ip, ip_addr_buf1), dst_subnet, ICMP_FILTER_DUMMY_PORT, false, fw_filter_err_str[err]);
         }
@@ -181,7 +181,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
         if (FW_DEBUG_OUTPUT) {
             sddf_printf("%sICMP remove rule id %u: %s\n",
-                fw_frmt_str[filter_config.webserver.interface], rule_id, fw_filter_err_str[err]);
+                fw_frmt_str[filter_config.interface], rule_id, fw_filter_err_str[err]);
         }
 
         seL4_SetMR(FILTER_RET_ERR, err);
@@ -189,7 +189,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
     }
     default:
         sddf_printf("%sICMP FILTER LOG: unknown request %lu on channel %u\n",
-            fw_frmt_str[filter_config.webserver.interface],
+            fw_frmt_str[filter_config.interface],
             microkit_msginfo_get_label(msginfo), ch);
         break;
     }
@@ -203,7 +203,7 @@ void notified(microkit_channel ch)
         filter();
     } else {
         sddf_dprintf("%sICMP FILTER LOG: Received notification on unknown channel: %d!\n",
-            fw_frmt_str[filter_config.webserver.interface], ch);
+            fw_frmt_str[filter_config.interface], ch);
     }
 }
 

--- a/examples/firewall/filters/tcp_filter.c
+++ b/examples/firewall/filters/tcp_filter.c
@@ -54,7 +54,7 @@ static void filter(void)
                 action = filter_state.default_action;
                 if (FW_DEBUG_OUTPUT) {
                     sddf_printf("%sTCP filter found no match, performing default action %s: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.webserver.interface], fw_filter_action_str[action],
+                        fw_frmt_str[filter_config.interface], fw_filter_action_str[action],
                         ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(tcp_hdr->src_port),
                         ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(tcp_hdr->dst_port));
                 }
@@ -67,14 +67,14 @@ static void filter(void)
 
                 if ((fw_err == FILTER_ERR_OKAY || fw_err == FILTER_ERR_DUPLICATE) && FW_DEBUG_OUTPUT) {
                     sddf_printf("%sTCP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        fw_frmt_str[filter_config.interface], rule_id,
                         ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(tcp_hdr->src_port),
                         ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(tcp_hdr->dst_port));
                 }
 
                 if (fw_err == FILTER_ERR_FULL) {
                     sddf_printf("%sTCP FILTER LOG: could not establish connection for rule %u: (ip %s, port %u) -> (ip %s, port %u): %s\n",
-                        fw_frmt_str[filter_config.webserver.interface],
+                        fw_frmt_str[filter_config.interface],
                         rule_id, ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(tcp_hdr->src_port),
                         ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(tcp_hdr->dst_port), fw_filter_err_str[fw_err]);
                 }
@@ -92,12 +92,12 @@ static void filter(void)
                 if (FW_DEBUG_OUTPUT) {
                     if (action == FILTER_ACT_ALLOW || action == FILTER_ACT_CONNECT) {
                         sddf_printf("%sTCP filter transmitting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            fw_frmt_str[filter_config.interface], rule_id,
                             ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(tcp_hdr->src_port),
                             ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(tcp_hdr->dst_port));
                     } else if (action == FILTER_ACT_ESTABLISHED) {
                         sddf_printf("%sTCP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            fw_frmt_str[filter_config.interface], rule_id,
                             ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(tcp_hdr->src_port),
                             ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(tcp_hdr->dst_port));
                     }
@@ -110,7 +110,7 @@ static void filter(void)
 
                 if (FW_DEBUG_OUTPUT) {
                     sddf_printf("%sTCP filter dropping via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        fw_frmt_str[filter_config.interface], rule_id,
                         ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(tcp_hdr->src_port),
                         ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(tcp_hdr->dst_port));
                 }
@@ -143,7 +143,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
         if (FW_DEBUG_OUTPUT) {
             sddf_printf("%sTCP filter changing default action from %u to %u\n",
-                fw_frmt_str[filter_config.webserver.interface], filter_state.default_action, action);
+                fw_frmt_str[filter_config.interface], filter_state.default_action, action);
         }
 
         fw_filter_err_t err = fw_filter_update_default_action(&filter_state, action);
@@ -168,7 +168,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
         if (FW_DEBUG_OUTPUT) {
             sddf_printf("%sTCP filter create rule %u: (ip %s, mask %u, port %u, any_port %u) - (%s) -> (ip %s, mask %u, port %u, any_port %u): %s\n",
-                fw_frmt_str[filter_config.webserver.interface], rule_id,
+                fw_frmt_str[filter_config.interface], rule_id,
                 ipaddr_to_string(src_ip, ip_addr_buf0), src_subnet, HTONS(src_port), src_port_any, fw_filter_action_str[action],
                 ipaddr_to_string(dst_ip, ip_addr_buf1), dst_subnet, HTONS(dst_port), dst_port_any, fw_filter_err_str[err]);
         }
@@ -183,7 +183,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
         if (FW_DEBUG_OUTPUT) {
             sddf_printf("%sTCP remove rule id %u: %s\n",
-                fw_frmt_str[filter_config.webserver.interface], rule_id, fw_filter_err_str[err]);
+                fw_frmt_str[filter_config.interface], rule_id, fw_filter_err_str[err]);
         }
 
         seL4_SetMR(FILTER_RET_ERR, err);
@@ -191,7 +191,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
     }
     default:
         sddf_printf("%sTCP FILTER LOG: unknown request %lu on channel %u\n",
-            fw_frmt_str[filter_config.webserver.interface],
+            fw_frmt_str[filter_config.interface],
             microkit_msginfo_get_label(msginfo), ch);
         break;
     }
@@ -205,7 +205,7 @@ void notified(microkit_channel ch)
         filter();
     } else {
         sddf_dprintf("%sTCP FILTER LOG: Received notification on unknown channel: %d!\n",
-            fw_frmt_str[filter_config.webserver.interface], ch);
+            fw_frmt_str[filter_config.interface], ch);
     }
 }
 

--- a/examples/firewall/filters/udp_filter.c
+++ b/examples/firewall/filters/udp_filter.c
@@ -54,7 +54,7 @@ static void filter(void)
                 action = filter_state.default_action;
                 if (FW_DEBUG_OUTPUT) {
                     sddf_printf("%sUDP filter found no match, performing default action %s: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.webserver.interface], fw_filter_action_str[action],
+                        fw_frmt_str[filter_config.interface], fw_filter_action_str[action],
                         ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(udp_hdr->src_port),
                         ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(udp_hdr->dst_port));
                 }
@@ -67,14 +67,14 @@ static void filter(void)
 
                 if ((fw_err == FILTER_ERR_OKAY || fw_err == FILTER_ERR_DUPLICATE) && FW_DEBUG_OUTPUT) {
                     sddf_printf("%sUDP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        fw_frmt_str[filter_config.interface], rule_id,
                         ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(udp_hdr->src_port),
                         ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(udp_hdr->dst_port));
                 }
 
                 if (fw_err == FILTER_ERR_FULL) {
                     sddf_printf("%sUDP FILTER LOG: could not establish connection for rule %u or default action %u: (ip %s, port %u) -> (ip %s, port %u): %s\n",
-                        fw_frmt_str[filter_config.webserver.interface],
+                        fw_frmt_str[filter_config.interface],
                         rule_id, default_action,
                         ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(udp_hdr->src_port),
                         ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(udp_hdr->dst_port), fw_filter_err_str[fw_err]);
@@ -93,12 +93,12 @@ static void filter(void)
                 if (FW_DEBUG_OUTPUT) {
                     if (action == FILTER_ACT_ALLOW || action == FILTER_ACT_CONNECT) {
                         sddf_printf("%sUDP filter transmitting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            fw_frmt_str[filter_config.interface], rule_id,
                             ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(udp_hdr->src_port),
                             ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(udp_hdr->dst_port));
                     } else if (action == FILTER_ACT_ESTABLISHED) {
                         sddf_printf("%sUDP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                            fw_frmt_str[filter_config.webserver.interface], rule_id,
+                            fw_frmt_str[filter_config.interface], rule_id,
                             ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(udp_hdr->src_port),
                             ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(udp_hdr->dst_port));
                     }
@@ -111,7 +111,7 @@ static void filter(void)
 
                 if (FW_DEBUG_OUTPUT) {
                     sddf_printf("%sUDP filter dropping via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.webserver.interface], rule_id,
+                        fw_frmt_str[filter_config.interface], rule_id,
                         ipaddr_to_string(ip_pkt->src_ip, ip_addr_buf0), HTONS(udp_hdr->src_port),
                         ipaddr_to_string(ip_pkt->dst_ip, ip_addr_buf1), HTONS(udp_hdr->dst_port));
                 }
@@ -144,7 +144,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
         if (FW_DEBUG_OUTPUT) {
             sddf_printf("%sUDP filter changing default action from %u to %u\n",
-                fw_frmt_str[filter_config.webserver.interface], filter_state.default_action, action);
+                fw_frmt_str[filter_config.interface], filter_state.default_action, action);
         }
 
         fw_filter_err_t err = fw_filter_update_default_action(&filter_state, action);
@@ -169,7 +169,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
         if (FW_DEBUG_OUTPUT) {
             sddf_printf("%sUDP filter create rule %u: (ip %s, mask %u, port %u, any_port %u) - (%s) -> (ip %s, mask %u, port %u, any_port %u): %s\n",
-                fw_frmt_str[filter_config.webserver.interface], rule_id,
+                fw_frmt_str[filter_config.interface], rule_id,
                 ipaddr_to_string(src_ip, ip_addr_buf0), src_subnet, HTONS(src_port), src_port_any, fw_filter_action_str[action],
                 ipaddr_to_string(dst_ip, ip_addr_buf1), dst_subnet, HTONS(dst_port), dst_port_any, fw_filter_err_str[err]);
         }
@@ -184,7 +184,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
 
         if (FW_DEBUG_OUTPUT) {
             sddf_printf("%sUDP remove rule id %u: %s\n",
-                fw_frmt_str[filter_config.webserver.interface], rule_id, fw_filter_err_str[err]);
+                fw_frmt_str[filter_config.interface], rule_id, fw_filter_err_str[err]);
         }
 
         seL4_SetMR(FILTER_RET_ERR, err);
@@ -192,7 +192,7 @@ seL4_MessageInfo_t protected(microkit_channel ch, microkit_msginfo msginfo)
     }
     default:
         sddf_printf("%sUDP FILTER LOG: unknown request %lu on channel %u\n",
-            fw_frmt_str[filter_config.webserver.interface],
+            fw_frmt_str[filter_config.interface],
             microkit_msginfo_get_label(msginfo), ch);
         break;
     }
@@ -206,7 +206,7 @@ void notified(microkit_channel ch)
         filter();
     } else {
         sddf_dprintf("%sUDP FILTER LOG: Received notification on unknown channel: %d!\n",
-            fw_frmt_str[filter_config.webserver.interface], ch);
+            fw_frmt_str[filter_config.interface], ch);
     }
 }
 

--- a/examples/firewall/meta.py
+++ b/examples/firewall/meta.py
@@ -517,8 +517,8 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
         # Create arp req config
         network["configs"][arp_req] = FwArpRequesterConfig(
             network["num"],
-            network["mac"],
-            network["ip"],
+            macs[network["out_num"]],
+            ip_to_int(ips[network["out_num"]]),
             [router_arp_conn[1]],
             arp_cache[0],
             arp_cache_region.capacity
@@ -549,14 +549,12 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
 
         # Create router webserver config
         router_webserver_config = FwWebserverRouterConfig(
-            network["num"],
             router_update_ch.pd_b_id,
             routing_table[0],
             routing_table_region.capacity
         )
 
         webserver_router_config = FwWebserverRouterConfig(
-            network["num"],
             router_update_ch.pd_a_id,
             routing_table[1],
             routing_table_region.capacity
@@ -565,10 +563,10 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
         # Create router config
         network["configs"][router] = FwRouterConfig(
             network["num"],
-            network["mac"],
-            network["ip"],
+            macs[network["out_num"]],
             ip_to_int(ips[network["out_num"]]),
             subnet_bits[network["out_num"]],
+            network["ip"],
             router_in_virt_conn[0],
             None,
             router_out_virt_conn[0].conn,
@@ -611,7 +609,6 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
 
             # Create webserver configs
             filter_webserver_config = FwWebserverFilterConfig(
-                network["num"],
                 protocol,
                 filter_update_ch.pd_b_id,
                 FILTER_ACTION_ALLOW,
@@ -620,7 +617,6 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
             )
 
             webserver_filter_config = FwWebserverFilterConfig(
-                network["num"],
                 protocol,
                 filter_update_ch.pd_a_id,
                 FILTER_ACTION_ALLOW,
@@ -630,8 +626,7 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
 
             # Create filter config
             network["configs"][filter_pd] = FwFilterConfig(
-                network["mac"],
-                network["ip"],
+                network["num"],
                 filter_instances_region.capacity,
                 filter_router_conn[0],
                 filter_webserver_config,

--- a/include/lions/firewall/config.h
+++ b/include/lions/firewall/config.h
@@ -34,6 +34,7 @@ typedef struct fw_data_connection_resource {
 } fw_data_connection_resource_t;
 
 typedef struct fw_net_virt_tx_config {
+    /* Interface traffic is transmitted out of */
     uint8_t interface;
     fw_data_connection_resource_t active_clients[FW_MAX_FW_CLIENTS];
     uint8_t num_active_clients;
@@ -42,6 +43,7 @@ typedef struct fw_net_virt_tx_config {
 } fw_net_virt_tx_config_t;
 
 typedef struct fw_net_virt_rx_config {
+    /* Interface traffic is received from */
     uint8_t interface;
     uint16_t active_client_protocols[SDDF_NET_MAX_CLIENTS];
     fw_connection_resource_t free_clients[FW_MAX_FW_CLIENTS];
@@ -56,8 +58,11 @@ typedef struct fw_arp_connection {
 } fw_arp_connection_t;
 
 typedef struct fw_arp_requester_config {
+    /* Interface traffic is received from */
     uint8_t interface;
+    /* MAC address of output interface */
     uint8_t mac_addr[ETH_HWADDR_LEN];
+    /* IP address of output interface */
     uint32_t ip;
     fw_arp_connection_t arp_clients[FW_NUM_ARP_REQUESTER_CLIENTS];
     uint8_t num_arp_clients;
@@ -66,24 +71,31 @@ typedef struct fw_arp_requester_config {
 } fw_arp_requester_config_t;
 
 typedef struct fw_arp_responder_config {
+    /* Interface traffic is received from */
     uint8_t interface;
+    /* MAC address of input and output interface */
     uint8_t mac_addr[ETH_HWADDR_LEN];
+    /* IP address of input and output interface */
     uint32_t ip;
 } fw_arp_responder_config_t;
 
 typedef struct fw_webserver_router_config {
-    uint8_t interface;
     uint8_t routing_ch;
     region_resource_t routing_table;
     uint16_t routing_table_capacity;
 } fw_webserver_router_config_t;
 
 typedef struct fw_router_config {
+    /* Interface traffic is received from */
     uint8_t interface;
+    /* MAC address of output interface */
     uint8_t mac_addr[ETH_HWADDR_LEN];
+    /* IP address of output interface */
     uint32_t ip;
-    uint32_t out_ip;
-    uint8_t out_subnet;
+    /* Subnet bits of output interface */
+    uint32_t subnet;
+    /* IP address of input interface */
+    uint32_t in_ip;
     fw_connection_resource_t rx_free;
     fw_connection_resource_t rx_active;
     fw_connection_resource_t tx_active;
@@ -99,13 +111,13 @@ typedef struct fw_router_config {
 } fw_router_config_t;
 
 typedef struct fw_icmp_module_config {
+    /* IP address of interfaces */
     uint32_t ips[FW_NUM_INTERFACES];
     fw_connection_resource_t routers[FW_NUM_INTERFACES];
     uint8_t num_interfaces;
 } fw_icmp_module_config_t;
 
 typedef struct fw_webserver_filter_config {
-    uint8_t interface;
     uint16_t protocol;
     uint8_t ch;
     uint8_t default_action;
@@ -114,8 +126,8 @@ typedef struct fw_webserver_filter_config {
 } fw_webserver_filter_config_t;
 
 typedef struct fw_filter_config {
-    uint8_t mac_addr[ETH_HWADDR_LEN];
-    uint32_t ip;
+    /* Interface traffic is received from */
+    uint8_t interface;
     uint16_t instances_capacity;
     fw_connection_resource_t router;
     fw_webserver_filter_config_t webserver;
@@ -124,7 +136,9 @@ typedef struct fw_filter_config {
 } fw_filter_config_t;
 
 typedef struct fw_webserver_interface_config {
+    /* MAC address of interface */
     uint8_t mac_addr[ETH_HWADDR_LEN];
+    /* IP address of interface */
     uint32_t ip;
     fw_webserver_router_config_t router;
     fw_webserver_filter_config_t filters[FW_MAX_FILTERS];
@@ -132,6 +146,7 @@ typedef struct fw_webserver_interface_config {
 } fw_webserver_interface_config_t;
 
 typedef struct fw_webserver_config {
+    /* Interface traffic is received from */
     uint8_t interface;
     fw_connection_resource_t rx_active;
     region_resource_t data;


### PR DESCRIPTION
The ARP requester and router components are transmitting packets using the IP/MAC address of the firewall interface the packet was received on. They should instead be using the IP/MAC of the interface the packets are being transmitted out of.