### PR TITLE
Move fs helpers to library

### DIFF
--- a/components/micropython/Makefile
+++ b/components/micropython/Makefile
@@ -70,7 +70,7 @@ SRC_C = \
 	modfs_raw.c \
 	vfs_fs_file.c \
 	vfs_fs.c \
-	fs_helpers.c \
+	fs/helpers.c \
 	frozen_content.c \
 	extmod/modtime.c \
 	extmod/vfs.c \
@@ -122,6 +122,8 @@ endif
 
 # Define the required object files.
 OBJ = $(PY_CORE_O) $(addprefix $(BUILD)/, $(SRC_C:.c=.o))
+
+include $(LIONSOS)/lib/fs/helpers/fs_helpers.mk
 
 all: $(BUILD)/micropython.elf
 

--- a/components/micropython/micropython.c
+++ b/components/micropython/micropython.c
@@ -33,7 +33,7 @@
 #include "mpconfigport.h"
 #include "mphalport.h"
 #include "mpfirewallport.h"
-#include "fs_helpers.h"
+#include <lions/fs/helpers.h>
 
 __attribute__((__section__(".serial_client_config"))) serial_client_config_t serial_config;
 __attribute__((__section__(".timer_client_config"))) timer_client_config_t timer_config;
@@ -82,6 +82,10 @@ i2c_queue_handle_t i2c_queue_handle;
 #ifdef ENABLE_FRAMEBUFFER
 uintptr_t framebuffer_data_region = 0x30000000;
 #endif
+
+static void blocking_wait(microkit_channel ch) {
+    mp_cothread_wait(ch, MP_WAIT_NO_INTERRUPT);
+}
 
 static bool init_vfs(void) {
     mp_obj_t args[2] = {
@@ -210,6 +214,7 @@ void init(void) {
     firewall_enabled = (fw_config.rx_active.queue.vaddr != NULL);
 
     if (fs_enabled) {
+        fs_set_blocking_wait(blocking_wait);
         fs_command_queue = fs_config.server.command_queue.vaddr;
         fs_completion_queue = fs_config.server.completion_queue.vaddr;
         fs_share = fs_config.server.share.vaddr;

--- a/components/micropython/modfs_raw.c
+++ b/components/micropython/modfs_raw.c
@@ -6,7 +6,7 @@
 #include <microkit.h>
 #include "py/runtime.h"
 #include "micropython.h"
-#include "fs_helpers.h"
+#include <lions/fs/helpers.h>
 #include <fcntl.h>
 #include <string.h>
 

--- a/components/micropython/vfs_fs.c
+++ b/components/micropython/vfs_fs.c
@@ -11,7 +11,7 @@
 #include "extmod/vfs.h"
 #include "vfs_fs.h"
 #include "micropython.h"
-#include "fs_helpers.h"
+#include <lions/fs/helpers.h>
 
 #include <stdio.h>
 #include <string.h>

--- a/components/micropython/vfs_fs_file.c
+++ b/components/micropython/vfs_fs_file.c
@@ -7,7 +7,7 @@
 #include "py/mpthread.h"
 #include "py/runtime.h"
 #include "py/stream.h"
-#include "fs_helpers.h"
+#include <lions/fs/helpers.h>
 #include "micropython.h"
 #include <fcntl.h>
 #include <unistd.h>

--- a/include/lions/fs/helpers.h
+++ b/include/lions/fs/helpers.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <microkit.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <lions/fs/protocol.h>
 
@@ -22,4 +24,5 @@ void fs_process_completions(void);
 
 void fs_command_issue(fs_cmd_t cmd);
 void fs_command_complete(uint64_t request_id, fs_cmd_t *cmd, fs_cmpl_t *cmpl);
+void fs_set_blocking_wait(void(*f)(microkit_channel));
 int fs_command_blocking(fs_cmpl_t *cmpl, fs_cmd_t cmd);

--- a/lib/fs/helpers/fs_helpers.mk
+++ b/lib/fs/helpers/fs_helpers.mk
@@ -1,0 +1,10 @@
+#
+# Copyright 2024, UNSW
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# This Makefile snippet builds the FS helpers library
+#
+
+$(BUILD)/fs/helpers.o: $(LIONSOS)/lib/fs/helpers/helpers.c
+	${CC} ${CFLAGS} -c -o $@ $<


### PR DESCRIPTION
I've been looking at this as part of wasm fs stuff but this kind of stands alone so figured I'd open for feedback.

There was very little micropython specific functionality in `fs_helpers`. The main change in this commit (aside from moving the files) is to abstract these specifics away by requiring the provision of a custom "wait" function for `fs_command_blocking` (set with the new function `fs_set_blocking_wait`, on init). Includes for `fs_helpers.h` are also updated.

`blocking_wait` would in general simply be `microkit_cothread_wait_on_channel`, but MP does some extra interrupt handling as well hence the need for a custom function, which also helps avoid an explicit dependency on `libmicrokitco`.