### PR TITLE
Make micrpython-submodules if necessary

### DIFF
--- a/components/micropython/Makefile
+++ b/components/micropython/Makefile
@@ -11,7 +11,6 @@ LWIP := $(SDDF)/network/ipstacks/lwip
 MICROPYTHON_SRC := $(LIONSOS)/dep/micropython
 FROZEN_MANIFEST ?= $(MICROPYTHON_SRC)/extmod/asyncio/manifest.py
 
-
 # Include the core environment definitions; this will set $(TOP).
 include $(MICROPYTHON_SRC)/py/mkenv.mk
 
@@ -127,7 +126,9 @@ $(BUILD)/micropython.elf: $(OBJ) $(BUILD)/libi2c.o
 	$(Q)$(SIZE) $@
 
 $(OBJ): |${MPY_LIB_DIR}/README.md
-$(MPY_LIB_DIR)/README.md: submodules
+$(MPY_LIB_DIR)/README.md:
+	${MAKE} -C ${LIONSOS}/components/micropython submodules
+.PHONY: submodules
 
 # Include remaining core make rules.
 include $(TOP)/py/mkrules.mk


### PR DESCRIPTION
On a fresh checkout of LionsOS, you'll get the message when bulding anything to do with micropython,
  'Error: micropython-lib submodule is not initialized. Run 'make
  submodules''

Unfortunately it's not so easy to work out where or how to do this. So fix the issue here in the Makefile.