### PR TITLE
Add ICMP extensions

### DIFF
--- a/components/micropython/modfirewall.c
+++ b/components/micropython/modfirewall.c
@@ -10,6 +10,7 @@
 #include <sddf/util/printf.h>
 #include <lions/firewall/config.h>
 #include <lions/firewall/filter.h>
+#include <lions/firewall/ip.h>
 #include <lions/firewall/routing.h>
 
 #include "mpfirewallport.h"
@@ -28,7 +29,8 @@ typedef enum {
     OS_ERR_INVALID_ROUTE_NUM, /* Invalid route number supplied to route_get_nth */
     OS_ERR_INVALID_RULE_NUM,  /* Invalid route number supplied to rule_get_nth */
     OS_ERR_OUT_OF_MEMORY,     /* Data structures full */
-    OS_ERR_INTERNAL_ERROR     /* Unknown internal error */
+    OS_ERR_INTERNAL_ERROR,    /* Unknown internal error */
+    OS_ERR_UNSUPPORTED_ACTION /* Unsupported action for selected protocol */
 } fw_os_err_t;
 
 static const char *fw_os_err_str[] = {
@@ -44,8 +46,22 @@ static const char *fw_os_err_str[] = {
     "Route number supplied is greater than the number of routes.",
     "Rule number supplied is the default action rule index, or greater than the number of rules.",
     "Internal data structures are already at capacity.",
-    "Unknown internal error."
+    "Unknown internal error.",
+    "Unsupported action for the protocol selected."
 };
+
+static bool is_action_supported_for_filter(fw_webserver_filter_config_t *filter, uint8_t action)
+{
+    if (action == 0 || action > FW_FILTER_NUM_ACTIONS) {
+        return false;
+    }
+
+    if (filter->actions[action - 1]) {
+        return true;
+    }
+
+    return false;
+}
 
 /* Convert a routing error to OS error */
 static fw_os_err_t fw_routing_err_to_os_err(fw_routing_err_t routing_err)
@@ -82,6 +98,8 @@ static fw_os_err_t filter_err_to_os_err(fw_filter_err_t filter_err)
         return OS_ERR_CLASH;
     case FILTER_ERR_INVALID_RULE_ID:
         return OS_ERR_INVALID_RULE_ID;
+    case FILTER_ERR_UNSUPPORTED_ACTION:
+        return OS_ERR_UNSUPPORTED_ACTION;
     default:
         return OS_ERR_INTERNAL_ERROR;
     }
@@ -187,6 +205,53 @@ static mp_obj_t route_delete(mp_obj_t interface_idx_in, mp_obj_t route_id_in)
 
 static MP_DEFINE_CONST_FUN_OBJ_2(route_delete_obj, route_delete);
 
+/* Enable or disable ICMP ping responses on an interface */
+static mp_obj_t ping_response_set(mp_obj_t interface_idx_in, mp_obj_t enable_in) {
+    uint8_t interface_idx = mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    bool enable = mp_obj_is_true(enable_in);
+
+    microkit_mr_set(0, enable ? 1 : 0);
+    microkit_msginfo msginfo =
+        microkit_ppcall(fw_config.interfaces[interface_idx].router.routing_ch,
+                    microkit_msginfo_new(FW_SET_PING_RESPONSE, 1));
+
+    uint32_t result = microkit_mr_get(0);
+    if (result != 0) {
+        sddf_dprintf("WEBSERVER|LOG: Failed to set ping response\n");
+        mp_raise_OSError(OS_ERR_INTERNAL_ERROR);
+        return mp_const_none;
+    }
+
+    /* Store the state of the ping response */
+    webserver_state[interface_idx].ping_enabled = enable;
+
+    return mp_const_none;
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_2(ping_response_set_obj, ping_response_set);
+
+/* Get status of ICMP ping responses on an interface */
+static mp_obj_t ping_response_get(mp_obj_t interface_idx_in) {
+    uint8_t interface_idx = mp_obj_get_int(interface_idx_in);
+    if (interface_idx >= FW_NUM_INTERFACES) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n",
+                    fw_os_err_str[OS_ERR_INVALID_INTERFACE]);
+        mp_raise_OSError(OS_ERR_INVALID_INTERFACE);
+        return mp_const_none;
+    }
+
+    return mp_obj_new_bool(webserver_state[interface_idx].ping_enabled);
+}
+
+static MP_DEFINE_CONST_FUN_OBJ_1(ping_response_get_obj, ping_response_get);
+
 /* Count the number of routes in an interface routing table */
 static mp_obj_t route_count(mp_obj_t interface_idx_in)
 {
@@ -273,6 +338,13 @@ static mp_obj_t rule_add(mp_uint_t n_args, const mp_obj_t *args)
     if (protocol_match == fw_config.interfaces[interface_idx].num_filters) {
         sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_INVALID_PROTOCOL]);
         mp_raise_OSError(OS_ERR_INVALID_PROTOCOL);
+        return mp_const_none;
+    }
+
+    if (!is_action_supported_for_filter(&fw_config.interfaces[interface_idx].filters[protocol_match],
+                                        action)) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_UNSUPPORTED_ACTION]);
+        mp_raise_OSError(OS_ERR_UNSUPPORTED_ACTION);
         return mp_const_none;
     }
 
@@ -392,6 +464,13 @@ static mp_obj_t filter_set_default_action(mp_obj_t interface_idx_in, mp_obj_t pr
         return mp_const_none;
     }
 
+    if (!is_action_supported_for_filter(&fw_config.interfaces[interface_idx].filters[protocol_match],
+                                        action)) {
+        sddf_dprintf("WEBSERVER|LOG: %s\n", fw_os_err_str[OS_ERR_UNSUPPORTED_ACTION]);
+        mp_raise_OSError(OS_ERR_UNSUPPORTED_ACTION);
+        return mp_const_none;
+    }
+
     microkit_mr_set(FILTER_ARG_ACTION, action);
     microkit_msginfo msginfo = microkit_ppcall(fw_config.interfaces[interface_idx].filters[protocol_match].ch,
                                                microkit_msginfo_new(FW_SET_DEFAULT_ACTION, 1));
@@ -484,19 +563,21 @@ static mp_obj_t rule_get_nth(mp_obj_t interface_idx_in, mp_obj_t protocol_in, mp
 static MP_DEFINE_CONST_FUN_OBJ_3(rule_get_nth_obj, rule_get_nth);
 
 static const mp_rom_map_elem_t lions_firewall_module_globals_table[] = {
-    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_lions_firewall) },
-    { MP_ROM_QSTR(MP_QSTR_interface_mac_get), MP_ROM_PTR(&interface_get_mac_obj) },
-    { MP_ROM_QSTR(MP_QSTR_interface_ip_get), MP_ROM_PTR(&interface_get_ip_obj) },
-    { MP_ROM_QSTR(MP_QSTR_route_add), MP_ROM_PTR(&route_add_obj) },
-    { MP_ROM_QSTR(MP_QSTR_route_delete), MP_ROM_PTR(&route_delete_obj) },
-    { MP_ROM_QSTR(MP_QSTR_route_count), MP_ROM_PTR(&route_count_obj) },
-    { MP_ROM_QSTR(MP_QSTR_route_get_nth), MP_ROM_PTR(&route_get_nth_obj) },
-    { MP_ROM_QSTR(MP_QSTR_rule_add), MP_ROM_PTR(&rule_add_obj) },
-    { MP_ROM_QSTR(MP_QSTR_rule_delete), MP_ROM_PTR(&rule_delete_obj) },
-    { MP_ROM_QSTR(MP_QSTR_rule_count), MP_ROM_PTR(&rule_count_obj) },
-    { MP_ROM_QSTR(MP_QSTR_rule_get_nth), MP_ROM_PTR(&rule_get_nth_obj) },
-    { MP_ROM_QSTR(MP_QSTR_filter_get_default_action), MP_ROM_PTR(&filter_get_default_action_obj) },
-    { MP_ROM_QSTR(MP_QSTR_filter_set_default_action), MP_ROM_PTR(&filter_set_default_action_obj) },
+    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_lions_firewall)},
+    { MP_ROM_QSTR(MP_QSTR_interface_mac_get), MP_ROM_PTR(&interface_get_mac_obj)},
+    { MP_ROM_QSTR(MP_QSTR_interface_ip_get), MP_ROM_PTR(&interface_get_ip_obj)},
+    { MP_ROM_QSTR(MP_QSTR_route_add), MP_ROM_PTR(&route_add_obj)},
+    { MP_ROM_QSTR(MP_QSTR_route_delete), MP_ROM_PTR(&route_delete_obj)},
+    { MP_ROM_QSTR(MP_QSTR_route_count), MP_ROM_PTR(&route_count_obj)},
+    { MP_ROM_QSTR(MP_QSTR_route_get_nth), MP_ROM_PTR(&route_get_nth_obj)},
+    { MP_ROM_QSTR(MP_QSTR_ping_response_set), MP_ROM_PTR(&ping_response_set_obj)},
+    { MP_ROM_QSTR(MP_QSTR_ping_response_get), MP_ROM_PTR(&ping_response_get_obj)},
+    { MP_ROM_QSTR(MP_QSTR_rule_add), MP_ROM_PTR(&rule_add_obj)},
+    { MP_ROM_QSTR(MP_QSTR_rule_delete), MP_ROM_PTR(&rule_delete_obj)},
+    { MP_ROM_QSTR(MP_QSTR_rule_count), MP_ROM_PTR(&rule_count_obj)},
+    { MP_ROM_QSTR(MP_QSTR_rule_get_nth), MP_ROM_PTR(&rule_get_nth_obj)},
+    { MP_ROM_QSTR(MP_QSTR_filter_get_default_action), MP_ROM_PTR(&filter_get_default_action_obj)},
+    { MP_ROM_QSTR(MP_QSTR_filter_set_default_action), MP_ROM_PTR(&filter_set_default_action_obj)},
 };
 
 static MP_DEFINE_CONST_DICT(lions_firewall_module_globals, lions_firewall_module_globals_table);

--- a/components/micropython/mpfirewallport.h
+++ b/components/micropython/mpfirewallport.h
@@ -27,6 +27,7 @@ typedef struct fw_webserver_interface_state {
     fw_routing_table_t *routing_table;
     fw_filter_state_t filter_states[FW_MAX_FILTERS];
     uint16_t num_rules[FW_MAX_FILTERS];
+    bool ping_enabled;
 } fw_webserver_interface_state_t;
 
 extern fw_webserver_interface_state_t webserver_state[FW_NUM_INTERFACES];

--- a/examples/firewall/docker/scripts/autotest.sh
+++ b/examples/firewall/docker/scripts/autotest.sh
@@ -44,7 +44,7 @@ FONT_RED=$(printf '\033[31m')
 FONT_RESET=$(printf '\033[0m')
 
 REGEX_REACHABLE='[1-9][0-9]* received'
-REGEX_UNREACHABLE='Destination host unreachable'
+REGEX_UNREACHABLE='Destination Net Unreachable'
 
 TEMPLATE_SRC='$src_ip, $src_port, $src_subnet'
 TEMPLATE_DEST='$dest_ip, $dest_port, $dest_subnet'
@@ -288,32 +288,23 @@ test_icmp_ping_unreachable_host_external_to_internal() {
 }
 
 test_icmp_ping_firewall_from_internal_network() {
-    # Prevent test from running, but correctly report skip count
-    print_info "${INFO_SKIPPING_TEST}"
-    startSkipping
-    assertEquals 1 1
+    ip netns exec int \
+        ping -c "${COUNT}" -w "${TIMEOUT}" "${FW_INT_IP}" > "${RECEIVED}" 2>&1
 
-    # ip netns exec int \
-    #     ping -c "${COUNT}" -w "${TIMEOUT}" "${FW_INT_IP}" > "${RECEIVED}" 2>&1
-
-    # if ! grep -Eq --ignore-case "${REGEX_REACHABLE}" "${RECEIVED}"; then
-    #     fail "${ERROR_NO_ECHO_RESPONSE}"
-    #     print_log
-    # fi
+    if ! grep -Eq --ignore-case "${REGEX_REACHABLE}" "${RECEIVED}"; then
+        fail "${ERROR_NO_ECHO_RESPONSE}"
+        print_log
+    fi
 }
 
 test_icmp_ping_firewall_from_external_network() {
-    print_info "${INFO_SKIPPING_TEST}"
-    startSkipping
-    assertEquals 1 1
+    ip netns exec ext \
+        ping -c "${COUNT}" -w "${TIMEOUT}" "${FW_EXT_IP}" > "${RECEIVED}" 2>&1
 
-    # ip netns exec ext \
-    #     ping -c "${COUNT}" -w "${TIMEOUT}" "${FW_EXT_IP}" > "${RECEIVED}" 2>&1
-
-    # if ! grep -Eq --ignore-case "${REGEX_REACHABLE}" "${RECEIVED}"; then
-    #     fail "${ERROR_NO_ECHO_RESPONSE}"
-    #     print_log
-    # fi
+    if ! grep -Eq --ignore-case "${REGEX_REACHABLE}" "${RECEIVED}"; then
+        fail "${ERROR_NO_ECHO_RESPONSE}"
+        print_log
+    fi
 }
 
 #

--- a/examples/firewall/docker/scripts/net_setup.sh
+++ b/examples/firewall/docker/scripts/net_setup.sh
@@ -1,8 +1,6 @@
 # Copyright 2025, UNSW
 # SPDX-License-Identifier: BSD-2-Clause
 
-#!/bin/bash
-
 # -- Container script for setting up the network -- #
 
 # Create bridges to connect namespaces to taps

--- a/examples/firewall/filters/icmp_filter.c
+++ b/examples/firewall/filters/icmp_filter.c
@@ -24,11 +24,23 @@ __attribute__((__section__(".net_client_config"))) net_client_config_t net_confi
 net_queue_handle_t rx_queue;
 net_queue_handle_t tx_queue;
 fw_queue_t router_queue;
+fw_queue_t icmp_queue;
 
 /* Holds filtering rules and state */
 fw_filter_state_t filter_state;
 
 #define ICMP_FILTER_DUMMY_PORT 0
+
+/* ICMP request queue to send unreachable messages to ICMP module */
+static bool notify_icmp;
+
+static bool enqueue_icmp_unreachable(net_buff_desc_t buffer)
+{
+    uintptr_t pkt_vaddr = (uintptr_t)(net_config.rx_data.vaddr + buffer.io_or_offset);
+    bool enqueued = icmp_enqueue_error(&icmp_queue, ICMP_DEST_UNREACHABLE, ICMP_DEST_PORT_UNREACHABLE, pkt_vaddr);
+    notify_icmp |= enqueued;
+    return enqueued;
+}
 
 static void filter(void)
 {
@@ -48,36 +60,33 @@ static void filter(void)
             fw_action_t action = fw_filter_find_action(&filter_state, ip_hdr->src_ip, ICMP_FILTER_DUMMY_PORT,
                                                        ip_hdr->dst_ip, ICMP_FILTER_DUMMY_PORT, &rule_id);
 
-            /* Add an established connection in shared memory for corresponding filter */
-            if (action == FILTER_ACT_CONNECT) {
+            switch (action) {
+            case FILTER_ACT_CONNECT: {
+                /* Add an established connection in shared memory for corresponding filter */
                 fw_filter_err_t fw_err = fw_filter_add_instance(&filter_state, ip_hdr->src_ip, ICMP_FILTER_DUMMY_PORT,
-                                                                ip_hdr->dst_ip, ICMP_FILTER_DUMMY_PORT, rule_id);
+                                                                                ip_hdr->dst_ip, ICMP_FILTER_DUMMY_PORT, rule_id);
 
                 if ((fw_err == FILTER_ERR_OKAY || fw_err == FILTER_ERR_DUPLICATE) && FW_DEBUG_OUTPUT) {
-                    sddf_printf(
-                        "%sICMP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.interface], rule_id, ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0),
-                        ICMP_FILTER_DUMMY_PORT, ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
+                    sddf_printf("%sICMP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.interface], rule_id,
+                        ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
                 }
 
                 if (fw_err == FILTER_ERR_FULL) {
-                    sddf_printf("%sICMP FILTER LOG: could not establish connection for rule %u: (ip %s, port %u) -> "
-                                "(ip %s, port %u): %s\n",
-                                fw_frmt_str[filter_config.interface], rule_id,
-                                ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
-                                ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT,
-                                fw_filter_err_str[fw_err]);
+                    sddf_printf("%sICMP FILTER LOG: could not establish connection for rule %u: (ip %s, port %u) -> (ip %s, port %u): %s\n",
+                        fw_frmt_str[filter_config.interface], rule_id, ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT, fw_filter_err_str[fw_err]);
                 }
             }
-
-            /* Transmit the packet to the routing component */
-            if (action == FILTER_ACT_CONNECT || action == FILTER_ACT_ESTABLISHED || action == FILTER_ACT_ALLOW) {
-
-#ifdef NETWORK_HW_HAS_CHECKSUM
-                /* Reset the checksum as it's recalculated in hardware */
+            case FILTER_ACT_ESTABLISHED:
+            case FILTER_ACT_ALLOW: {
+                /* Transmit the packet to the routing component */
+                /* Reset the checksum if it's recalculated in hardware */
+                #ifdef NETWORK_HW_HAS_CHECKSUM
                 icmp_hdr_t *icmp_hdr = (icmp_hdr_t *)(pkt_vaddr + transport_layer_offset(ip_hdr));
                 icmp_hdr->check = 0;
-#endif
+                #endif
 
                 err = fw_enqueue(&router_queue, &buffer);
                 assert(!err);
@@ -86,18 +95,36 @@ static void filter(void)
                 if (FW_DEBUG_OUTPUT) {
                     if (action == FILTER_ACT_ALLOW || action == FILTER_ACT_CONNECT) {
                         sddf_printf("%sICMP filter transmitting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                                    fw_frmt_str[filter_config.interface], rule_id,
-                                    ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
-                                    ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
+                            fw_frmt_str[filter_config.interface], rule_id,
+                            ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                            ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
                     } else if (action == FILTER_ACT_ESTABLISHED) {
-                        sddf_printf(
-                            "%sICMP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        sddf_printf("%sICMP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
                             fw_frmt_str[filter_config.interface], rule_id,
                             ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
                             ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
                     }
                 }
-            } else if (action == FILTER_ACT_DROP) {
+                break;
+            }
+            case FILTER_ACT_REJECT: {
+                icmp_hdr_t *icmp_hdr = (icmp_hdr_t *)(pkt_vaddr + ICMP_HDR_OFFSET);
+                uint8_t icmp_type = icmp_hdr->type;
+                /* An ICMP error message shouldn't be sent upon reception of another ICMP error message */
+                if (!icmp_is_error_message(icmp_type)) {
+                    /* Enqueue an ICMP port unreachable message */
+                    enqueue_icmp_unreachable(buffer);
+                }
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sICMP filter rejecting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.interface], rule_id,
+                        ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
+                }
+            }
+            case FILTER_ACT_DROP:
+            default: {
                 /* Return the buffer to the rx virtualiser */
                 err = net_enqueue_free(&rx_queue, buffer);
                 assert(!err);
@@ -105,11 +132,12 @@ static void filter(void)
 
                 if (FW_DEBUG_OUTPUT) {
                     sddf_printf("%sICMP filter dropping via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                                fw_frmt_str[filter_config.interface], rule_id,
-                                ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
-                                ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
+                        fw_frmt_str[filter_config.interface], rule_id,
+                        ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), ICMP_FILTER_DUMMY_PORT,
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), ICMP_FILTER_DUMMY_PORT);
                 }
-            }
+                break;
+            }}
         }
 
         net_request_signal_active(&rx_queue);
@@ -153,6 +181,13 @@ microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo)
         uint32_t dst_ip = microkit_mr_get(FILTER_ARG_DST_IP);
         uint8_t src_subnet = microkit_mr_get(FILTER_ARG_SRC_SUBNET);
         uint8_t dst_subnet = microkit_mr_get(FILTER_ARG_DST_SUBNET);
+
+        /* ICMP filter does not support this action */
+        if (action == 0 || action > FW_FILTER_NUM_ACTIONS || !filter_config.webserver.actions[action - 1]) {
+            microkit_mr_set(FILTER_RET_ERR, FILTER_ERR_UNSUPPORTED_ACTION);
+            return microkit_msginfo_new(0, 1);
+        }
+
         uint16_t rule_id = 0;
         fw_filter_err_t err = fw_filter_add_rule(&filter_state, src_ip, ICMP_FILTER_DUMMY_PORT, dst_ip,
                                                  ICMP_FILTER_DUMMY_PORT, src_subnet, dst_subnet, true, true, action,
@@ -200,6 +235,13 @@ void notified(microkit_channel ch)
         sddf_dprintf("%sICMP FILTER LOG: Received notification on unknown channel: %d!\n",
                      fw_frmt_str[filter_config.interface], ch);
     }
+
+    if (notify_icmp) {
+        sddf_printf("%sICMP filter notifying ICMP module on channel %u\n",
+            fw_frmt_str[filter_config.interface], filter_config.icmp_module.ch);
+        notify_icmp = false;
+        microkit_notify(filter_config.icmp_module.ch);
+    }
 }
 
 void init(void)
@@ -212,8 +254,10 @@ void init(void)
     fw_queue_init(&router_queue, filter_config.router.queue.vaddr, sizeof(net_buff_desc_t),
                   filter_config.router.capacity);
 
-    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.rule_id_bitmap.vaddr,
-                         filter_config.webserver.rules_capacity, filter_config.internal_instances.vaddr,
-                         filter_config.external_instances.vaddr, filter_config.instances_capacity,
-                         (fw_action_t)filter_config.webserver.default_action);
+    fw_queue_init(&icmp_queue, filter_config.icmp_module.queue.vaddr,
+        sizeof(icmp_req_t), filter_config.icmp_module.capacity);
+
+    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.rule_id_bitmap.vaddr, filter_config.webserver.rules_capacity,
+        filter_config.internal_instances.vaddr, filter_config.external_instances.vaddr, filter_config.instances_capacity,
+        (fw_action_t)filter_config.webserver.default_action);
 }

--- a/examples/firewall/filters/tcp_filter.c
+++ b/examples/firewall/filters/tcp_filter.c
@@ -48,35 +48,33 @@ static void filter(void)
             fw_action_t action = fw_filter_find_action(&filter_state, ip_hdr->src_ip, tcp_hdr->src_port, ip_hdr->dst_ip,
                                                        tcp_hdr->dst_port, &rule_id);
 
-            /* Add an established connection in shared memory for corresponding filter */
-            if (action == FILTER_ACT_CONNECT) {
+            switch (action) {
+            case FILTER_ACT_CONNECT: {
+                /* Add an established connection in shared memory for corresponding filter */
                 fw_filter_err_t fw_err = fw_filter_add_instance(&filter_state, ip_hdr->src_ip, tcp_hdr->src_port,
-                                                                ip_hdr->dst_ip, tcp_hdr->dst_port, rule_id);
+                                                                                ip_hdr->dst_ip, tcp_hdr->dst_port, rule_id);
 
                 if ((fw_err == FILTER_ERR_OKAY || fw_err == FILTER_ERR_DUPLICATE) && FW_DEBUG_OUTPUT) {
-                    sddf_printf(
-                        "%sTCP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.interface], rule_id, ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0),
-                        htons(tcp_hdr->src_port), ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1),
-                        htons(tcp_hdr->dst_port));
+                    sddf_printf("%sTCP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.interface], rule_id,
+                        ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(tcp_hdr->src_port),
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(tcp_hdr->dst_port));
                 }
 
                 if (fw_err == FILTER_ERR_FULL) {
-                    sddf_printf("%sTCP FILTER LOG: could not establish connection for rule %u: (ip %s, port %u) -> (ip "
-                                "%s, port %u): %s\n",
-                                fw_frmt_str[filter_config.interface], rule_id,
-                                ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(tcp_hdr->src_port),
-                                ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(tcp_hdr->dst_port),
-                                fw_filter_err_str[fw_err]);
+                    sddf_printf("%sTCP FILTER LOG: could not establish connection for rule %u: (ip %s, port %u) -> (ip %s, port %u): %s\n",
+                        fw_frmt_str[filter_config.interface],
+                        rule_id, ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(tcp_hdr->src_port),
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(tcp_hdr->dst_port), fw_filter_err_str[fw_err]);
                 }
             }
-
-            /* Transmit the packet to the routing component */
-            if (action == FILTER_ACT_CONNECT || action == FILTER_ACT_ESTABLISHED || action == FILTER_ACT_ALLOW) {
-                /* Reset the checksum as it's recalculated in hardware */
-#ifdef NETWORK_HW_HAS_CHECKSUM
+            case FILTER_ACT_ESTABLISHED:
+            case FILTER_ACT_ALLOW: {
+                /* Transmit the packet to the routing component */
+                /* Reset the checksum if it's recalculated in hardware */
+                #ifdef NETWORK_HW_HAS_CHECKSUM
                 tcp_hdr->check = 0;
-#endif
+                #endif
 
                 err = fw_enqueue(&router_queue, &buffer);
                 assert(!err);
@@ -85,18 +83,20 @@ static void filter(void)
                 if (FW_DEBUG_OUTPUT) {
                     if (action == FILTER_ACT_ALLOW || action == FILTER_ACT_CONNECT) {
                         sddf_printf("%sTCP filter transmitting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                                    fw_frmt_str[filter_config.interface], rule_id,
-                                    ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(tcp_hdr->src_port),
-                                    ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(tcp_hdr->dst_port));
+                            fw_frmt_str[filter_config.interface], rule_id,
+                            ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(tcp_hdr->src_port),
+                            ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(tcp_hdr->dst_port));
                     } else if (action == FILTER_ACT_ESTABLISHED) {
-                        sddf_printf(
-                            "%sTCP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        sddf_printf("%sTCP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
                             fw_frmt_str[filter_config.interface], rule_id,
                             ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(tcp_hdr->src_port),
                             ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(tcp_hdr->dst_port));
                     }
                 }
-            } else if (action == FILTER_ACT_DROP) {
+                break;
+            }
+            case FILTER_ACT_DROP:
+            default: {
                 /* Return the buffer to the rx virtualiser */
                 err = net_enqueue_free(&rx_queue, buffer);
                 assert(!err);
@@ -104,11 +104,12 @@ static void filter(void)
 
                 if (FW_DEBUG_OUTPUT) {
                     sddf_printf("%sTCP filter dropping via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                                fw_frmt_str[filter_config.interface], rule_id,
-                                ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(tcp_hdr->src_port),
-                                ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(tcp_hdr->dst_port));
+                        fw_frmt_str[filter_config.interface], rule_id,
+                        ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(tcp_hdr->src_port),
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(tcp_hdr->dst_port));
                 }
-            }
+                break;
+            }}
         }
 
         net_request_signal_active(&rx_queue);
@@ -156,6 +157,13 @@ microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo)
         uint8_t dst_subnet = microkit_mr_get(FILTER_ARG_DST_SUBNET);
         bool src_port_any = microkit_mr_get(FILTER_ARG_SRC_ANY_PORT);
         bool dst_port_any = microkit_mr_get(FILTER_ARG_DST_ANY_PORT);
+
+        /* TCP filter does not support this action */
+        if (action == 0 || action > FW_FILTER_NUM_ACTIONS || !filter_config.webserver.actions[action - 1]) {
+            microkit_mr_set(FILTER_RET_ERR, FILTER_ERR_UNSUPPORTED_ACTION);
+            return microkit_msginfo_new(0, 1);
+        }
+
         uint16_t rule_id = 0;
         fw_filter_err_t err = fw_filter_add_rule(&filter_state, src_ip, src_port, dst_ip, dst_port, src_subnet,
                                                  dst_subnet, src_port_any, dst_port_any, action, &rule_id);

--- a/examples/firewall/filters/udp_filter.c
+++ b/examples/firewall/filters/udp_filter.c
@@ -17,6 +17,7 @@
 #include <lions/firewall/ip.h>
 #include <lions/firewall/udp.h>
 #include <lions/firewall/queue.h>
+#include <lions/firewall/icmp.h>
 
 __attribute__((__section__(".fw_filter_config"))) fw_filter_config_t filter_config;
 __attribute__((__section__(".net_client_config"))) net_client_config_t net_config;
@@ -25,9 +26,21 @@ __attribute__((__section__(".net_client_config"))) net_client_config_t net_confi
 net_queue_handle_t rx_queue;
 net_queue_handle_t tx_queue;
 fw_queue_t router_queue;
+fw_queue_t icmp_queue;
 
 /* Holds filtering rules and state */
 fw_filter_state_t filter_state;
+
+/* ICMP request queue to send unreachable messages to ICMP module */
+static bool notify_icmp;
+
+static bool enqueue_icmp_unreachable(net_buff_desc_t buffer)
+{
+    uintptr_t pkt_vaddr = (uintptr_t)(net_config.rx_data.vaddr + buffer.io_or_offset);
+    bool enqueued = icmp_enqueue_error(&icmp_queue, ICMP_DEST_UNREACHABLE, ICMP_DEST_PORT_UNREACHABLE, pkt_vaddr);
+    notify_icmp |= enqueued;
+    return enqueued;
+}
 
 static void filter(void)
 {
@@ -45,39 +58,35 @@ static void filter(void)
             udp_hdr_t *udp_hdr = (udp_hdr_t *)(pkt_vaddr + transport_layer_offset(ip_hdr));
 
             uint16_t rule_id = 0;
-            fw_action_t action = fw_filter_find_action(&filter_state, ip_hdr->src_ip, udp_hdr->src_port, ip_hdr->dst_ip,
-                                                       udp_hdr->dst_port, &rule_id);
+            fw_action_t action = fw_filter_find_action(&filter_state, ip_hdr->src_ip, udp_hdr->src_port,
+                                                                   ip_hdr->dst_ip, udp_hdr->dst_port, &rule_id);
 
-            /* Add an established connection in shared memory for corresponding filter */
-            if (action == FILTER_ACT_CONNECT) {
+            switch (action) {
+            case FILTER_ACT_CONNECT: {
+                /* Add an established connection in shared memory for corresponding filter */
                 fw_filter_err_t fw_err = fw_filter_add_instance(&filter_state, ip_hdr->src_ip, udp_hdr->src_port,
-                                                                ip_hdr->dst_ip, udp_hdr->dst_port, rule_id);
+                                                                                ip_hdr->dst_ip, udp_hdr->dst_port, rule_id);
 
                 if ((fw_err == FILTER_ERR_OKAY || fw_err == FILTER_ERR_DUPLICATE) && FW_DEBUG_OUTPUT) {
-                    sddf_printf(
-                        "%sUDP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                        fw_frmt_str[filter_config.interface], rule_id, ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0),
-                        htons(udp_hdr->src_port), ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1),
-                        htons(udp_hdr->dst_port));
+                    sddf_printf("%sUDP filter establishing connection via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.interface], rule_id,
+                        ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(udp_hdr->src_port),
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(udp_hdr->dst_port));
                 }
 
                 if (fw_err == FILTER_ERR_FULL) {
-                    sddf_printf("%sUDP FILTER LOG: could not establish connection for rule %u: (ip %s, port %u) -> (ip "
-                                "%s, port %u): %s\n",
-                                fw_frmt_str[filter_config.interface], rule_id,
-                                ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(udp_hdr->src_port),
-                                ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(udp_hdr->dst_port),
-                                fw_filter_err_str[fw_err]);
+                    sddf_printf("%sUDP FILTER LOG: could not establish connection for rule %u: (ip %s, port %u) -> (ip %s, port %u): %s\n",
+                        fw_frmt_str[filter_config.interface], rule_id, ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(udp_hdr->src_port),
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(udp_hdr->dst_port), fw_filter_err_str[fw_err]);
                 }
             }
-
-            /* Transmit the packet to the routing component */
-            if (action == FILTER_ACT_CONNECT || action == FILTER_ACT_ESTABLISHED || action == FILTER_ACT_ALLOW) {
-
-                /* Reset the checksum as it's recalculated in hardware */
-#ifdef NETWORK_HW_HAS_CHECKSUM
+            case FILTER_ACT_ESTABLISHED:
+            case FILTER_ACT_ALLOW: {
+                /* Transmit the packet to the routing component */
+                /* Reset the checksum if it's recalculated in hardware */
+                #ifdef NETWORK_HW_HAS_CHECKSUM
                 udp_hdr->check = 0;
-#endif
+                #endif
                 err = fw_enqueue(&router_queue, &buffer);
                 assert(!err);
                 transmitted = true;
@@ -85,18 +94,31 @@ static void filter(void)
                 if (FW_DEBUG_OUTPUT) {
                     if (action == FILTER_ACT_ALLOW || action == FILTER_ACT_CONNECT) {
                         sddf_printf("%sUDP filter transmitting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                                    fw_frmt_str[filter_config.interface], rule_id,
-                                    ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(udp_hdr->src_port),
-                                    ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(udp_hdr->dst_port));
+                            fw_frmt_str[filter_config.interface], rule_id,
+                            ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(udp_hdr->src_port),
+                            ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(udp_hdr->dst_port));
                     } else if (action == FILTER_ACT_ESTABLISHED) {
-                        sddf_printf(
-                            "%sUDP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        sddf_printf("%sUDP filter transmitting via external rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
                             fw_frmt_str[filter_config.interface], rule_id,
                             ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(udp_hdr->src_port),
                             ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(udp_hdr->dst_port));
                     }
                 }
-            } else if (action == FILTER_ACT_DROP) {
+                break;
+            }
+            case FILTER_ACT_REJECT: {
+                /* Enqueue an ICMP port unreachable message */
+                enqueue_icmp_unreachable(buffer);
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sUDP filter rejecting via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
+                        fw_frmt_str[filter_config.interface], rule_id,
+                        ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(udp_hdr->src_port),
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(udp_hdr->dst_port));
+                }
+            }
+            case FILTER_ACT_DROP:
+            default: {
                 /* Return the buffer to the rx virtualiser */
                 err = net_enqueue_free(&rx_queue, buffer);
                 assert(!err);
@@ -104,13 +126,13 @@ static void filter(void)
 
                 if (FW_DEBUG_OUTPUT) {
                     sddf_printf("%sUDP filter dropping via rule %u: (ip %s, port %u) -> (ip %s, port %u)\n",
-                                fw_frmt_str[filter_config.interface], rule_id,
-                                ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(udp_hdr->src_port),
-                                ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(udp_hdr->dst_port));
+                        fw_frmt_str[filter_config.interface], rule_id,
+                        ipaddr_to_string(ip_hdr->src_ip, ip_addr_buf0), htons(udp_hdr->src_port),
+                        ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf1), htons(udp_hdr->dst_port));
                 }
-            }
+                break;
+            }}
         }
-
         net_request_signal_active(&rx_queue);
         reprocess = false;
 
@@ -156,6 +178,13 @@ microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo)
         uint8_t dst_subnet = microkit_mr_get(FILTER_ARG_DST_SUBNET);
         bool src_port_any = microkit_mr_get(FILTER_ARG_SRC_ANY_PORT);
         bool dst_port_any = microkit_mr_get(FILTER_ARG_DST_ANY_PORT);
+
+        /* UDP filter does not support this action */
+        if (action == 0 || action > FW_FILTER_NUM_ACTIONS || !filter_config.webserver.actions[action - 1]) {
+            microkit_mr_set(FILTER_RET_ERR, FILTER_ERR_UNSUPPORTED_ACTION);
+            return microkit_msginfo_new(0, 1);
+        }
+
         uint16_t rule_id = 0;
         fw_filter_err_t err = fw_filter_add_rule(&filter_state, src_ip, src_port, dst_ip, dst_port, src_subnet,
                                                  dst_subnet, src_port_any, dst_port_any, action, &rule_id);
@@ -202,6 +231,15 @@ void notified(microkit_channel ch)
         sddf_dprintf("%sUDP FILTER LOG: Received notification on unknown channel: %d!\n",
                      fw_frmt_str[filter_config.interface], ch);
     }
+
+    if (notify_icmp) {
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sUDP filter notifying ICMP module on channel %u\n",
+                fw_frmt_str[filter_config.interface], filter_config.icmp_module.ch);
+        }
+        notify_icmp = false;
+        microkit_notify(filter_config.icmp_module.ch);
+    }
 }
 
 void init(void)
@@ -214,8 +252,10 @@ void init(void)
     fw_queue_init(&router_queue, filter_config.router.queue.vaddr, sizeof(net_buff_desc_t),
                   filter_config.router.capacity);
 
-    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.rule_id_bitmap.vaddr,
-                         filter_config.webserver.rules_capacity, filter_config.internal_instances.vaddr,
-                         filter_config.external_instances.vaddr, filter_config.instances_capacity,
-                         (fw_action_t)filter_config.webserver.default_action);
+    fw_queue_init(&icmp_queue, filter_config.icmp_module.queue.vaddr,
+        sizeof(icmp_req_t), filter_config.icmp_module.capacity);
+
+    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.rule_id_bitmap.vaddr, filter_config.webserver.rules_capacity,
+        filter_config.internal_instances.vaddr, filter_config.external_instances.vaddr, filter_config.instances_capacity,
+        (fw_action_t)filter_config.webserver.default_action);
 }

--- a/examples/firewall/icmp/icmp_module.c
+++ b/examples/firewall/icmp/icmp_module.c
@@ -26,118 +26,207 @@ __attribute__((__section__(".int_net_client_config"))) net_client_config_t int_n
 net_client_config_t *net_configs[FW_NUM_INTERFACES] = {&ext_net_config, &int_net_config};
 
 net_queue_handle_t net_queue[FW_NUM_INTERFACES];
-fw_queue_t icmp_queue[FW_NUM_INTERFACES];
+fw_queue_t router_icmp_queue[FW_NUM_INTERFACES];
+fw_queue_t filter_icmp_queue[FW_NUM_INTERFACES][FW_MAX_FILTERS];
+
+static bool process_icmp_request(icmp_req_t *req, uint8_t out_int, bool *transmitted)
+{
+    if (req->type != ICMP_DEST_UNREACHABLE && req->type != ICMP_ECHO_REPLY && req->type != ICMP_TTL_EXCEED) {
+        sddf_printf("ICMP module: unsupported ICMP type %u!\n", req->type);
+        return false;
+    }
+
+    if (net_queue_empty_free(&net_queue[out_int])) {
+        return false;
+    }
+
+    net_buff_desc_t buffer = {};
+    int err = net_dequeue_free(&net_queue[out_int], &buffer);
+    assert(!err);
+
+    uintptr_t pkt_vaddr = (uintptr_t)(net_configs[out_int]->tx_data.vaddr + buffer.io_or_offset);
+
+    /* Construct ethernet header */
+    eth_hdr_t *eth_hdr = (eth_hdr_t *)pkt_vaddr;
+    memcpy(&eth_hdr->ethdst_addr, &req->eth_hdr.ethsrc_addr, ETH_HWADDR_LEN);
+    memcpy(&eth_hdr->ethsrc_addr, &icmp_config.interfaces[out_int].mac_addr, ETH_HWADDR_LEN);
+    eth_hdr->ethtype = htons(ETH_TYPE_IP);
+
+    /* Construct IP packet */
+    ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
+    ip_hdr->version = 4;
+    ip_hdr->ihl = IPV4_HDR_LEN_MIN / 4;
+    ip_hdr->dscp = IPV4_DSCP_NET_CTRL;
+    ip_hdr->ecn = 0;
+
+    /* Not fragmenting this IP packet, set all other fields to 0 */
+    ip_hdr->id = 0;
+    ip_hdr->frag_offset1 = 0;
+    ip_hdr->frag_offset2 = 0;
+    ip_hdr->more_frag = 0;
+    ip_hdr->no_frag = 1;
+    ip_hdr->reserved = 0;
+
+    /* Recommended inital value of ttl is 64 hops according to the TCP/IP spec */
+    ip_hdr->ttl = 64;
+    ip_hdr->protocol = IPV4_PROTO_ICMP;
+
+    /* Source of IP packet is the firewall */
+    ip_hdr->src_ip = icmp_config.interfaces[out_int].ip;
+    /* Destination depends on ICMP type - set in switch below */
+
+    /* Construct ICMP packet */
+    icmp_hdr_t *icmp_hdr = (icmp_hdr_t *)(pkt_vaddr + ICMP_HDR_OFFSET);
+    icmp_hdr->type = req->type;
+    icmp_hdr->code = req->code;
+
+    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, ntohs(req->ip_hdr.tot_len) - IPV4_HDR_LEN_MIN);
+
+    /* Handle each ICMP type separately */
+    switch (req->type) {
+        case ICMP_ECHO_REPLY: {
+            /* Destination is the sender */
+            ip_hdr->dst_ip = req->ip_hdr.src_ip;
+
+            /* Total length of ICMP destination unreachable IP packet */
+            uint16_t icmp_total_len = (uint16_t)(ICMP_COMMON_HDR_LEN + sizeof(icmp_echo_t) + req->echo.payload_len);
+            ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + icmp_total_len);
+
+            /* Construct ICMP echo reply: 4 bytes (id + seq) */
+            icmp_echo_t *icmp_echo = (icmp_echo_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET);
+
+            /* Set Echo-specific fields from the request */
+            icmp_echo->id = htons(req->echo.echo_id);
+            icmp_echo->seq = htons(req->echo.echo_seq);
+
+            /* Copy the actual Echo payload data (the 'ping' data) */
+            memcpy(icmp_echo->data, req->echo.data, req->echo.payload_len);
+            break;
+        }
+
+        case ICMP_DEST_UNREACHABLE:
+            /* Destination is original packet's source */
+            ip_hdr->dst_ip = req->ip_hdr.src_ip;
+
+            /* Total length of ICMP destination unreachable IP packet */
+            ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_DEST_LEN);
+
+            /* Construct ICMP destination unreachable packet */
+            icmp_dest_t *icmp_dest = (icmp_dest_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET);
+
+            /* Unused must be set to 0, as well as optional fields we are not currently using */
+            icmp_dest->unused = 0;
+            icmp_dest->len = 0;
+            icmp_dest->nexthop_mtu = 0;
+
+            /* Copy IP header */
+            memcpy(&icmp_dest->ip_hdr, &req->ip_hdr, IPV4_HDR_LEN_MIN);
+
+            /* Copy first bytes of data if applicable */
+            memcpy(&icmp_dest->data, req->dest.data, to_copy);
+            break;
+        case ICMP_TTL_EXCEED:
+            /* Destination is original packet's source */
+            ip_hdr->dst_ip = req->ip_hdr.src_ip;
+
+            /* Total length of ICMP time exceeded IP packet */
+            ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_TIME_EXCEEDED_LEN);
+
+            /* Construct ICMP time exceeded packet */
+            icmp_time_exceeded_t *icmp_time_exceeded = (icmp_time_exceeded_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET);
+
+            /* Unused must be set to 0 */
+            icmp_time_exceeded->unused = 0;
+
+            /* Copy IP header */
+            memcpy(&icmp_time_exceeded->ip_hdr, &req->ip_hdr, IPV4_HDR_LEN_MIN);
+
+            /* Copy first bytes of data if applicable */
+            memcpy(&icmp_time_exceeded->data, req->time_exceeded.data, to_copy);
+            break;
+        case ICMP_REDIRECT_MSG:
+            /* Destination is original packet's source */
+            ip_hdr->dst_ip = req->ip_hdr.src_ip;
+
+            /* Total length of ICMP redicrt IP packet */
+            ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_REDIRECT_LEN);
+
+            /* Construct ICMP redirect packet */
+            icmp_redirect_t *icmp_redirect = (icmp_redirect_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET);
+
+            /* Set the gateway IP address*/
+            icmp_redirect->gateway_ip = req->redirect.gateway_ip;
+
+            /* Copy IP header */
+            memcpy(&icmp_redirect->ip_hdr, &req->ip_hdr, IPV4_HDR_LEN_MIN);
+            /* Copy first bytes of data if applicable */
+            memcpy(&icmp_redirect->data, req->redirect.data, to_copy);
+            break;
+        default:
+            return false;
+    }
+
+    /* Set checksum to 0 and leave calculation to hardware. If this is not supported, calculate IP and ICMP checksums here */
+    icmp_hdr->check = 0;
+    ip_hdr->check = 0;
+
+    uint16_t ip_tot_len = ntohs(ip_hdr->tot_len);
+
+    #ifndef NETWORK_HW_HAS_CHECKSUM
+    /* ICMP checksum is calculated over entire ICMP packet */
+    icmp_hdr->check = fw_internet_checksum(icmp_hdr, ip_tot_len - IPV4_HDR_LEN_MIN);
+    /* IP checksum is calculated only over IP header */
+    ip_hdr->check = fw_internet_checksum(ip_hdr, IPV4_HDR_LEN_MIN);
+    #endif
+
+    buffer.len = ip_tot_len + ETH_HDR_LEN;
+    err = net_enqueue_active(&net_queue[out_int], buffer);
+    transmitted[out_int] = true;
+    assert(!err);
+
+    if (FW_DEBUG_OUTPUT) {
+        sddf_printf("ICMP module sending packet for ip %s with type %u, code %u\n",
+            ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf0), icmp_hdr->type, icmp_hdr->code);
+    }
+
+    return true;
+}
 
 static void generate_icmp(void)
 {
     bool transmitted[FW_NUM_INTERFACES] = {false};
+
+    /* Process ICMP requests from filters */
     for (uint8_t out_int = 0; out_int < icmp_config.num_interfaces; out_int++) {
-        while (!fw_queue_empty(&icmp_queue[out_int]) && !net_queue_empty_free(&net_queue[out_int])) {
+        for (uint8_t filter_idx = 0; filter_idx < icmp_config.interfaces[out_int].num_filters; filter_idx++) {
+            while (!fw_queue_empty(&filter_icmp_queue[out_int][filter_idx])) {
+                icmp_req_t req = {0};
+                int err = fw_dequeue(&filter_icmp_queue[out_int][filter_idx], &req);
+                assert(!err);
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("ICMP module: processing filter %u ICMP request type %u code %u on interface %u\n",
+                        filter_idx, req.type, req.code, out_int);
+                }
+
+                process_icmp_request(&req, out_int, transmitted);
+            }
+        }
+    }
+
+    /* Process ICMP requests from routers */
+    for (uint8_t out_int = 0; out_int < icmp_config.num_interfaces; out_int++) {
+        while (!fw_queue_empty(&router_icmp_queue[out_int])) {
             icmp_req_t req = {0};
-            int err = fw_dequeue(&icmp_queue[out_int], &req);
-            assert(!err);
-
-            /* Currently we only support destination unreachable ICMP traffic */
-            if (req.type != ICMP_DEST_UNREACHABLE) {
-                sddf_printf("ICMP module: Interface %u requested unsupported ICMP type %u!\n", out_int, req.type);
-                continue;
-            }
-
-            net_buff_desc_t buffer = {};
-            err = net_dequeue_free(&net_queue[out_int], &buffer);
-            assert(!err);
-
-            uintptr_t pkt_vaddr = (uintptr_t)(net_configs[out_int]->tx_data.vaddr + buffer.io_or_offset);
-
-            /* Construct ethernet header */
-            eth_hdr_t *eth_hdr = (eth_hdr_t *)pkt_vaddr;
-            memcpy(&eth_hdr->ethdst_addr, &req.eth_hdr.ethsrc_addr, ETH_HWADDR_LEN);
-            memcpy(&eth_hdr->ethsrc_addr, &req.eth_hdr.ethdst_addr, ETH_HWADDR_LEN);
-            eth_hdr->ethtype = htons(ETH_TYPE_IP);
-
-            /* Construct IP packet */
-            ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
-            ip_hdr->version = 4;
-            ip_hdr->ihl = IPV4_HDR_LEN_MIN / 4;
-            ip_hdr->dscp = IPV4_DSCP_NET_CTRL;
-            ip_hdr->ecn = 0;
-
-            /* Not fragmenting this IP packet, set all other fields to 0 */
-            ip_hdr->id = 0;
-            ip_hdr->frag_offset1 = 0;
-            ip_hdr->frag_offset2 = 0;
-            ip_hdr->more_frag = 0;
-            ip_hdr->no_frag = 1;
-            ip_hdr->reserved = 0;
-
-            /* Recommended inital value of ttl is 64 hops according to the TCP/IP spec */
-            ip_hdr->ttl = 64;
-            ip_hdr->protocol = IPV4_PROTO_ICMP;
-
-            /* Source of IP packet is the firewall */
-            ip_hdr->src_ip = icmp_config.ips[out_int];
-            ip_hdr->dst_ip = req.ip_hdr.src_ip;
-
-            /* Construct ICMP packet */
-            icmp_hdr_t *icmp_hdr = (icmp_hdr_t *)(pkt_vaddr + ICMP_HDR_OFFSET);
-            icmp_hdr->type = req.type;
-            icmp_hdr->code = req.code;
-
-            /* Handle each ICMP type separately */
-            switch (req.type) {
-            case ICMP_DEST_UNREACHABLE:
-
-                    /* Total length of ICMP destination unreachable IP packet */
-                    // TODO: Should this be less if the source packet did not
-                    // contain 8 bytes of data?
-                ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_DEST_LEN);
-
-                    /* Construct ICMP destination unreachable packet */
-                icmp_dest_t *icmp_dest = (icmp_dest_t *)(pkt_vaddr + ICMP_DEST_OFFSET);
-
-                    /* Unused must be set to 0, as well as optional fields we
-                    are not currently using */
-                icmp_dest->unused = 0;
-                icmp_dest->len = 0;
-                icmp_dest->nexthop_mtu = 0;
-
-                    /* Copy IP header */
-                memcpy(&icmp_dest->ip_hdr, &req.ip_hdr, IPV4_HDR_LEN_MIN);
-
-                    /* Copy first bytes of data if applicable */
-                    // TODO: If the source packet did not contain 8 bytes of
-                    // data, should the rest be zero-filled?
-                uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(req.ip_hdr.tot_len) - IPV4_HDR_LEN_MIN);
-                memcpy(&icmp_dest->data, req.data, to_copy);
-                break;
-
-            default:
-                sddf_printf("ICMP module tried to construct an unsupported ICMP type %u packet for interface %u!\n",
-                            req.type, out_int);
-                break;
-            }
-
-            /* Set checksum to 0 and leave calculation to hardware. If this is
-            no supported, calculate IP and ICMP checksums here */
-            icmp_hdr->check = 0;
-            ip_hdr->check = 0;
-
-#ifndef NETWORK_HW_HAS_CHECKSUM
-            /* ICMP checksum is calculated over entire ICMP packet */
-            icmp_hdr->check = fw_internet_checksum(icmp_hdr, htons(ip_hdr->tot_len) - IPV4_HDR_LEN_MIN);
-            /* IP checksum is calculated only over IP header */
-            ip_hdr->check = fw_internet_checksum(ip_hdr, IPV4_HDR_LEN_MIN);
-#endif
-
-            buffer.len = htons(ip_hdr->tot_len) + ETH_HDR_LEN;
-            err = net_enqueue_active(&net_queue[out_int], buffer);
-            transmitted[out_int] = true;
+            int err = fw_dequeue(&router_icmp_queue[out_int], &req);
             assert(!err);
 
             if (FW_DEBUG_OUTPUT) {
-                sddf_printf("ICMP module sending packet for ip %s with type %u, code %u\n",
-                            ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf0), icmp_hdr->type, icmp_hdr->code);
+                sddf_printf("ICMP module: processing router ICMP request type %u code %u on interface %u\n",
+                    req.type, req.code, out_int);
             }
+
+            process_icmp_request(&req, out_int, transmitted);
         }
     }
 
@@ -150,19 +239,28 @@ static void generate_icmp(void)
 
 void init(void)
 {
-    for (int i = 0; i < icmp_config.num_interfaces; i++) {
+    for (int out = 0; out < icmp_config.num_interfaces; out++) {
         /* Setup the queue with the router. */
-        fw_queue_init(&icmp_queue[i], icmp_config.routers[i].queue.vaddr, sizeof(icmp_req_t),
-                      icmp_config.routers[i].capacity);
+        fw_queue_init(&router_icmp_queue[out], icmp_config.interfaces[out].router.queue.vaddr,
+            sizeof(icmp_req_t), icmp_config.interfaces[out].router.capacity);
 
         /* Setup transmit queues with the transmit virtualisers. */
-        net_queue_init(&net_queue[i], net_configs[i]->tx.free_queue.vaddr, net_configs[i]->tx.active_queue.vaddr,
-                       net_configs[i]->tx.num_buffers);
-        net_buffers_init(&net_queue[i], 0);
+        net_queue_init(&net_queue[out], net_configs[out]->tx.free_queue.vaddr,
+            net_configs[out]->tx.active_queue.vaddr, net_configs[out]->tx.num_buffers);
+        net_buffers_init(&net_queue[out], 0);
+
+        /* Setup queues with filters */
+        for (int i = 0; i < icmp_config.interfaces[out].num_filters; i++) {
+            fw_queue_init(&filter_icmp_queue[out][i], icmp_config.interfaces[out].filters[i].queue.vaddr,
+                sizeof(icmp_req_t), icmp_config.interfaces[out].filters[i].capacity);
+        }
     }
 }
 
 void notified(microkit_channel ch)
 {
+    if (FW_DEBUG_OUTPUT) {
+        sddf_printf("ICMP module: notified on channel %u, generating ICMP packets\n", ch);
+    }
     generate_icmp();
 }

--- a/examples/firewall/meta.py
+++ b/examples/firewall/meta.py
@@ -448,6 +448,11 @@ def fw_shared_region(
 
 
 def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
+    filter_actions = {
+        ip_protocol_udp: [1, 1, 1, 1],
+        ip_protocol_tcp: [1, 1, 0, 1],
+        ip_protocol_icmp: [1, 1, 1, 1],
+    }
     serial_node = dtb.node(board.serial)
     assert serial_node is not None
     ethernet_node0 = dtb.node(board.ethernet0)
@@ -693,13 +698,17 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
     )
 
     icmp_module_config = FwIcmpModuleConfig(
-        list(ip_to_int(ip) for ip in ips),
-        [icmp_ext_router_conn[1], icmp_int_router_conn[1]],
-        2,
+        [FwIcmpModuleInterfaceConfig([], 0, icmp_ext_router_conn[1], [],),
+         FwIcmpModuleInterfaceConfig([], 0, icmp_int_router_conn[1], [],)]
     )
 
     networks[int_net]["icmp_module"] = icmp_int_router_conn[0]
     networks[ext_net]["icmp_module"] = icmp_ext_router_conn[0]
+
+    icmp_module_config = FwIcmpModuleConfig(
+        [FwIcmpModuleInterfaceConfig([], 0, icmp_ext_router_conn[1], [],),
+         FwIcmpModuleInterfaceConfig([], 0, icmp_int_router_conn[1], [],)]
+    )
 
     # Create webserver config
     webserver_config = FwWebserverConfig(
@@ -717,6 +726,10 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
         in_virt = network["in_virt"]
         arp_req = network["arp_req"]
         arp_resp = network["arp_resp"]
+
+        # Set IP and MAC for ICMP module interface
+        icmp_module_config.interfaces[network["num"]].mac_addr = network["mac"]
+        icmp_module_config.interfaces[network["num"]].ip = network["ip"]
 
         # Create a firewall data connection between router and output virt with
         # the rx dma region as data region
@@ -869,6 +882,18 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
                 dma_buffer_queue_region.region_size,
             )
 
+            # Create a firewall connection for UDP and ICMP filters to send ICMP requests to ICMP module
+            filter_icmp_conn = None
+            if protocol == ip_protocol_udp or protocol == ip_protocol_icmp:
+                filter_icmp_conn = fw_connection(
+                    filter_pd,
+                    icmp_module,
+                    icmp_queue_buffer.capacity,
+                    icmp_queue_region.region_size,
+                )
+                # Store ICMP module's end of the connection
+                icmp_module_config.interfaces[network["num"]].filters.append(filter_icmp_conn[1])
+
             # Connect filter as rx only network client
             network["in_net"].add_client_with_copier(filter_pd, tx=False)
             network["configs"][in_virt].active_client_ethtypes.append(eththype_ip)
@@ -906,6 +931,7 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
                 FILTER_ACTION_ALLOW,
                 filter_rules[0],
                 filter_rules_buffer.capacity,
+                filter_actions[protocol],
             )
 
             webserver_filter_config = FwWebserverFilterConfig(
@@ -914,6 +940,7 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
                 FILTER_ACTION_ALLOW,
                 filter_rules[1],
                 filter_rules_buffer.capacity,
+                filter_actions[protocol],
             )
 
             # Create filter config
@@ -925,6 +952,7 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
                 None,
                 None,
                 rule_bitmap_region,
+                filter_icmp_conn[0] if filter_icmp_conn else None,
             )
 
             network["configs"][router].filters.append((filter_router_conn[1]))
@@ -956,8 +984,6 @@ def generate(sdf_file: str, output_dir: str, dtb: DeviceTree):
     networks[int_net]["configs"][networks[int_net]["router"]].rx_active = (
         router_webserver_conn[0]
     )
-
-    # Add ICMP module
 
     # Create filter instance regions
     for protocol, filter_pd in networks[int_net]["filters"].items():

--- a/examples/firewall/routing/routing.c
+++ b/examples/firewall/routing/routing.c
@@ -59,6 +59,7 @@ static bool tx_webserver; /* Packet has been transmitted to the webserver */
 static bool returned; /* Buffer has been returned to the rx virtualiser */
 static bool notify_arp; /* Arp request has been enqueued */
 static bool notify_icmp; /* Request has been enqueued to ICMP module */
+static bool ping_response_enabled = false; /* Whether to reply to ICMP echo requests */
 
 /* Masks for checking whether it is a broadcast address or not */
 #define MULTICAST_IP_MASK 0xf0000000
@@ -68,30 +69,16 @@ const uint8_t broadcast_mac_addr[] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 
 /* Enqueue a request to the ICMP module to transmit a destination unreachable
 packet back to source */
-static int enqueue_icmp_unreachable(net_buff_desc_t buffer)
+static bool enqueue_icmp_unreachable(net_buff_desc_t buffer)
 {
-    icmp_req_t req = { 0 };
-    req.type = ICMP_DEST_UNREACHABLE;
-    req.code = ICMP_DEST_HOST_UNREACHABLE;
-
-    /* Copy ethernet header into ICMP request */
     uintptr_t pkt_vaddr = data_vaddr + buffer.io_or_offset;
-    memcpy(&req.eth_hdr, (void *)pkt_vaddr, ETH_HDR_LEN);
-
-    /* Copy IP header into ICMP request */
     ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
-    memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
-
-    /* Copy first bytes of data if applicable */
-    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(ip_hdr->tot_len) - IPV4_HDR_LEN_MIN);
-    memcpy(req.data, (void *)(pkt_vaddr + IPV4_HDR_OFFSET + IPV4_HDR_LEN_MIN), to_copy);
-
-    int err = fw_enqueue(&icmp_queue, &req);
-    if (!err) {
-        notify_icmp = true;
-    }
-
-    return err;
+    bool is_host = ((ip_hdr->dst_ip & subnet_mask(router_config.subnet)) !=
+        (router_config.ip & subnet_mask(router_config.subnet)));
+    uint8_t code = is_host ? ICMP_DEST_HOST_UNREACHABLE : ICMP_DEST_NET_UNREACHABLE;
+    bool enqueued = icmp_enqueue_error(&icmp_queue, ICMP_DEST_UNREACHABLE, code, pkt_vaddr);
+    notify_icmp |= enqueued;
+    return enqueued;
 }
 
 static void transmit_packet(net_buff_desc_t buffer, uint8_t *mac_addr)
@@ -145,8 +132,8 @@ static void process_arp_waiting(void)
             /* Invalid response, drop packet associated with the IP address */
             pkt_waiting_node_t *node = root;
             for (uint16_t i = 0; i < root->num_children + 1; i++) {
-                err = enqueue_icmp_unreachable(node->buffer);
-                if (FW_DEBUG_OUTPUT && err) {
+                bool icmp_enqueued = enqueue_icmp_unreachable(node->buffer);
+                if (FW_DEBUG_OUTPUT && !icmp_enqueued) {
                     sddf_dprintf("%sROUTING LOG: Could not enqueue ICMP unreachable!\n",
                                  fw_frmt_str[router_config.interface]);
                 }
@@ -180,22 +167,6 @@ static void route(void)
             eth_hdr_t *eth_hdr = (eth_hdr_t *)pkt_vaddr;
             ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
 
-            /*
-             * Decrement the TTL field. If it reaches 0 protocol is
-             * that we drop the packet in this router.
-             *
-             * NOTE: We drop non-IPv4 packets. This case should be
-             * handled by the protocol virtualiser.
-             */
-            if (eth_hdr->ethtype != htons(ETH_TYPE_IP) || ip_hdr->ttl <= 1) {
-                err = fw_enqueue(&rx_free, &buffer);
-                assert(!err);
-                returned = true;
-                continue;
-            }
-
-            ip_hdr->ttl -= 1;
-
             if (FW_DEBUG_OUTPUT) {
                 sddf_printf("%sRouter received packet for ip %s with buffer number %lu\n",
                             fw_frmt_str[router_config.interface], ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf0),
@@ -220,6 +191,30 @@ static void route(void)
                 assert(!err);
                 returned = true;
                 continue;
+            }
+
+            /* --- Handle ICMP echo request to firewall's own IP --- */
+            if (eth_hdr->ethtype == htons(ETH_TYPE_IP) &&
+                ip_hdr->protocol == IPV4_PROTO_ICMP &&
+                ip_hdr->dst_ip == router_config.in_ip) {
+
+                if (!ping_response_enabled) {
+                    /* Ping responses are disabled, return buffer */
+                    err = fw_enqueue(&rx_free, &buffer);
+                    assert(!err);
+                    returned = true;
+                    continue;
+                }
+
+                icmp_hdr_t *icmp_hdr = (icmp_hdr_t *)(pkt_vaddr + ICMP_HDR_OFFSET);
+                if (icmp_hdr->type == ICMP_ECHO_REQ) {
+                    notify_icmp |= icmp_enqueue_echo_reply(&icmp_queue, data_vaddr + buffer.io_or_offset);
+                    /* Return the original buffer */
+                    err = fw_enqueue(&rx_free, &buffer);
+                    assert(!err);
+                    returned = true;
+                    continue;
+                }
             }
 
             /* Find the next hop address. */
@@ -249,21 +244,6 @@ static void route(void)
                             ipaddr_to_string(next_hop, ip_addr_buf1), interface);
             }
 
-            /* No route, drop packet  */
-            if (interface == ROUTING_OUT_NONE
-                || (router_config.interface == FW_EXTERNAL_INTERFACE_ID && interface == ROUTING_OUT_SELF)) {
-
-                if (FW_DEBUG_OUTPUT) {
-                    sddf_printf("%sRouter found no route for ip %s, dropping packet\n",
-                                fw_frmt_str[router_config.interface], ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf0));
-                }
-
-                err = fw_enqueue(&rx_free, &buffer);
-                assert(!err);
-                returned = true;
-                continue;
-            }
-
             /* Packet destined for webserver */
             if (router_config.interface == FW_INTERNAL_INTERFACE_ID && interface == ROUTING_OUT_SELF) {
                 tcp_hdr_t *tcp_pkt = (tcp_hdr_t *)(pkt_vaddr + transport_layer_offset(ip_hdr));
@@ -288,6 +268,40 @@ static void route(void)
                 continue;
             }
 
+            /*
+             * Decrement the TTL field. If it reaches 0 protocol is
+             * that we drop the packet in this router.
+             *
+             * NOTE: We drop non-IPv4 packets. This case should be
+             * handled by the protocol virtualiser.
+             */
+            if (eth_hdr->ethtype != htons(ETH_TYPE_IP) || ip_hdr->ttl <= 1) {
+                notify_icmp |= icmp_enqueue_error(&icmp_queue, ICMP_TTL_EXCEED, ICMP_TIME_EXCEEDED_TTL, data_vaddr + buffer.io_or_offset);
+                err = fw_enqueue(&rx_free, &buffer);
+                assert(!err);
+                returned = true;
+                continue;
+            }
+
+            ip_hdr->ttl -= 1;
+
+            /* No route, drop packet  */
+            if (interface == ROUTING_OUT_NONE
+                || (router_config.interface == FW_EXTERNAL_INTERFACE_ID && interface == ROUTING_OUT_SELF)) {
+
+                if (FW_DEBUG_OUTPUT) {
+                    sddf_printf("%sRouter found no route for ip %s, dropping packet\n",
+                                fw_frmt_str[router_config.interface], ipaddr_to_string(ip_hdr->dst_ip, ip_addr_buf0));
+                }
+
+                enqueue_icmp_unreachable(buffer);
+
+                err = fw_enqueue(&rx_free, &buffer);
+                assert(!err);
+                returned = true;
+                continue;
+            }
+
             fw_arp_entry_t *arp = fw_arp_table_find_entry(&arp_table, next_hop);
             /* destination unreachable or no space to store packet or send ARP request, drop packet */
             if ((arp != NULL && arp->state == ARP_STATE_UNREACHABLE)
@@ -295,8 +309,7 @@ static void route(void)
                 || (arp == NULL && fw_queue_full(&arp_req_queue))) {
 
                 if (arp != NULL && arp->state == ARP_STATE_UNREACHABLE) {
-                    int icmp_err = enqueue_icmp_unreachable(buffer);
-                    if (icmp_err) {
+                    if (!enqueue_icmp_unreachable(buffer)) {
                         sddf_dprintf("%sROUTING LOG: Could not enqueue ICMP unreachable!\n",
                                      fw_frmt_str[router_config.interface]);
                     }
@@ -331,7 +344,6 @@ static void route(void)
 
                 continue;
             }
-
             /* valid arp entry found, transmit packet */
             transmit_packet(buffer, arp->mac_addr);
         }
@@ -416,6 +428,16 @@ microkit_msginfo protected(microkit_channel ch, microkit_msginfo msginfo)
         }
 
         microkit_mr_set(ROUTER_RET_ERR, err);
+        return microkit_msginfo_new(0, 1);
+    }
+    case FW_SET_PING_RESPONSE: {
+        ping_response_enabled = (bool)microkit_mr_get(0);
+        if (FW_DEBUG_OUTPUT) {
+            sddf_printf("%sRouter ping response %s\n",
+                fw_frmt_str[router_config.interface],
+                ping_response_enabled ? "enabled" : "disabled");
+        }
+        microkit_mr_set(0, 0); /* success */
         return microkit_msginfo_new(0, 1);
     }
     default:

--- a/examples/firewall/ui_server.py
+++ b/examples/firewall/ui_server.py
@@ -28,7 +28,8 @@ OSErrInvalidRouteNum = 9
 OSErrInvalidRuleNum = 10
 OSErrOutOfMemory = 11
 OSErrInternalError = 12
-OSErrInvalidInput = 13
+OSErrUnsupportedAction = 13
+OSErrInvalidInput = 14
 
 OSErrStrings = [
     "Ok.",
@@ -44,6 +45,7 @@ OSErrStrings = [
     "Rule number supplied is the default action rule index, or greater than the number of rules.",
     "Internal data structures are already at capacity.",
     "Unknown internal error.",
+    "Unsupported action for the protocol selected.",
     "Input supplied does not match the format of the field."
 ]
 
@@ -51,12 +53,7 @@ UnknownErrStr = "Unexpected unknown error."
 
 numInterfaces = 2
 
-interfaceStringsRouters = [
-    "internal",
-    "external",
-]
-
-interfaceStringsFilters = [
+interfaceStrings = [
     "external",
     "internal"
 ]
@@ -75,7 +72,8 @@ protocolNums = {
 actionNums = {
     1: "Allow",
     2: "Drop",
-    3: "Connect"
+    3: "Reject",
+    4: "Connect"
 }
 
 defaultActionRuleIdx = 0
@@ -147,11 +145,11 @@ def tupleToMac(macList):
 def interfaceStringToInt(componentType, interfaceStr):
   if componentType == "router":
       for i in range(numInterfaces):
-        if interfaceStr == interfaceStringsRouters[i]:
+        if interfaceStr == interfaceStrings[1-i]:
             return i
   elif componentType == "filter":
     for i in range(numInterfaces):
-        if interfaceStr == interfaceStringsFilters[i]:
+        if interfaceStr == interfaceStrings[i]:
             return i
 
     print(f"UI SERVER|ERR: Supplied interface string {interfaceStr} does not match existing interfaces.")
@@ -419,6 +417,41 @@ def addRule(request, protocolStr):
         print(f"UI SERVER|ERR: Unknown Error: addRule: {exception}.")
         return {"error": UnknownErrStr}, 404
 
+###### Ping Response methods ######
+# Set ping response for an interface
+@app.route('/api/ping/<string:interfaceStr>/<int:enabled>', methods=['POST'])
+def setPingResponse(request, interfaceStr, enabled):
+    try:
+        interface = interfaceStringToInt("filter", interfaceStr)
+        lions_firewall.ping_response_set(interface, bool(enabled))
+        return {
+            "interface": interfaceStringsCap[interface],
+            "ping_enabled": bool(enabled)
+        }
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: setPingResponse: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: setPingResponse: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
+@app.route('/api/ping/<string:interfaceStr>/', methods=['GET'])
+def getPing(request, interfaceStr):
+    try:
+        interface = interfaceStringToInt("filter", interfaceStr)
+
+        enabled = lions_firewall.ping_response_get(interface)
+        return {
+            "interface": interfaceStringsCap[interface],
+            "ping_enabled": bool(enabled)
+        }
+    except OSError as OSErr:
+        print(f"UI SERVER|ERR: OS Error: getRules: {OSErrStrings[OSErr.errno]}")
+        return {"error": OSErrStrings[OSErr.errno]}, 404
+    except Exception as exception:
+        print(f"UI SERVER|ERR: Unknown Error: getRules: {exception}.")
+        return {"error": UnknownErrStr}, 404
+
 
 ############ Web UI routes ############
 
@@ -435,7 +468,7 @@ def index(request):
   <body>
     <h1>Firewall Configuration</h1>
     <nav>
-      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a> | <a href="/ping_settings">Ping Settings</a>
     </nav>
   </body>
 </html>
@@ -455,7 +488,7 @@ def index(request):
   <body>
     <h1>Firewall Configuration</h1>
     <nav>
-      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a> | <a href="/ping_settings">Ping Settings</a>
     </nav>
     <div id="interfaces-container">
       <table border="1">
@@ -519,7 +552,7 @@ def config(request):
   <body>
     <h1>Routing Configuration Page</h1>
     <nav>
-      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a> | <a href="/ping_settings">Ping Settings</a>
     </nav>
 
     <h2>Internal Interface Routing Table</h2>
@@ -637,9 +670,9 @@ def config(request):
           var interfaceInternal = document.getElementById('new-interface-internal').checked;
           var interface;
           if (interfaceInternal) {
-            interface = 0;
-          } else if (interfaceExternal) {
             interface = 1;
+          } else if (interfaceExternal) {
+            interface = 0;
           } else {
             alert("Invalid interface supplied.");
             return;
@@ -685,7 +718,7 @@ def rules(request, protocol):
   <body>
     <h1>Firewall Rules</h1>
     <nav>
-      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a> | <a href="/ping_settings">Ping Settings</a>
     </nav>
     <div style="display: flex; flex-direction: column; margin-top: 1rem">
       <a href="/rules/udp">UDP</a>
@@ -700,7 +733,8 @@ def rules(request, protocol):
         <select name="internal-default-action" id="internal-default-action">
           <option value="1">Allow</option>
           <option value="2">Drop</option>
-          <option value="3">Connect</option>
+          <option value="3">Reject</option>
+          <option value="4">Connect</option>
         </select>
         <button id="internal-set-default-action-btn">Update Default</button>
       </div>
@@ -731,7 +765,8 @@ def rules(request, protocol):
           <option value="">...</option>
           <option value="1">Allow</option>
           <option value="2">Drop</option>
-          <option value="3">Connect</option>
+          <option value="3">Reject</option>
+          <option value="4">Connect</option>
         </select>
         <button id="external-set-default-action-btn">Update Default</button>
       </div>
@@ -768,7 +803,8 @@ def rules(request, protocol):
         <option value="">Rule Action</option>
         <option value="1">Allow</option>
         <option value="2">Drop</option>
-        <option value="3">Connect</option>
+        <option value="3">Reject</option>
+        <option value="4">Connect</option>
       </select>
       <button id="add-rule-btn">Add Rule</button>
     </p>
@@ -891,9 +927,9 @@ def rules(request, protocol):
           var interfaceExternal = document.getElementById('new-interface-external').checked;
           var interface;
           if (interfaceInternal) {
-            interface = 1;
-          } else if (interfaceExternal) {
             interface = 0;
+          } else if (interfaceExternal) {
+            interface = 1;
           } else {
             alert("Invalid interface supplied.");
             return;
@@ -958,7 +994,7 @@ def rules(request):
   <body>
     <h1>Firewall Rules</h1>
     <nav>
-      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a> | <a href="/ping_settings">Ping Settings</a>
     </nav>
     <div style="display: inline-block; margin-top: 1rem">
       <a href="/rules/udp">UDP</a>
@@ -988,5 +1024,87 @@ body {
 }
 """
     return Response(body=css, headers={'Content-Type': 'text/css'})
+@app.route('/ping_settings')
+def ping_settings(request):
+    html = """
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Ping Settings</title>
+    <link rel="stylesheet" href="/main.css">
+  </head>
+  <body>
+    <h1>Ping Response Settings</h1>
+    <nav>
+      <a href="/">Home</a> | <a href="/routing_config">Routing Config</a> | <a href="/rules">Rules</a> | <a href="/interface">Interface</a> | <a href="/ping_settings">Ping Settings</a>
+  </nav>
+
+    <h2>Toggle Ping Response</h2>
+    <p>Control whether the firewall responds to ICMP echo requests (ping) on each interface. Default disabled for all interfaces.</p>
+
+    <div id="ping-controls-container"></div>
+
+    <script>
+      function togglePing(interfaceName, enabled) {
+        fetch('/api/ping/' + interfaceName + '/' + (enabled ? 1 : 0), {
+          method: 'POST'
+        })
+        .then(response => response.json())
+        .then(data => {
+          var statusSpan = document.getElementById(interfaceName + '-status');
+          if (data.error) {
+            statusSpan.textContent = 'Error: ' + data.error;
+            statusSpan.style.color = 'red';
+          } else {
+            statusSpan.textContent = data.ping_enabled ? 'Enabled' : 'Disabled';
+            statusSpan.style.color = data.ping_enabled ? 'green' : 'gray';
+          }
+        })
+        .catch(err => {
+          alert('Error toggling ping response');
+        });
+      }
+
+      document.addEventListener("DOMContentLoaded", function() {
+        const container = document.getElementById('ping-controls-container');
+        const interfaceNames = ['internal', 'external'];
+
+        interfaceNames.forEach(interfaceName => {
+            const interfaceDiv = document.createElement('div');
+            interfaceDiv.className = 'ping-control';
+
+            interfaceDiv.innerHTML = `
+                <h3>${interfaceName.charAt(0).toUpperCase() + interfaceName.slice(1)}</h3>
+                <button onclick="togglePing('${interfaceName}', true)">Enable Ping</button>
+                <button onclick="togglePing('${interfaceName}', false)">Disable Ping</button>
+                <span id="${interfaceName}-status">Loading...</span>
+            `;
+            container.appendChild(interfaceDiv);
+
+            fetch('/api/ping/' + interfaceName + '/')
+                .then(response => response.json())
+                .then(data => {
+                    const statusSpan = document.getElementById(interfaceName + '-status');
+                    if (data.error) {
+                        statusSpan.textContent = 'Error: ' + data.error;
+                        statusSpan.style.color = 'red';
+                    } else {
+                        statusSpan.textContent = data.ping_enabled ? 'Enabled' : 'Disabled';
+                        statusSpan.style.color = data.ping_enabled ? 'green' : 'gray';
+                    }
+                })
+                .catch(err => {
+                    const statusSpan = document.getElementById(interfaceName + '-status');
+                    statusSpan.textContent = 'Error loading status';
+                    statusSpan.style.color = 'red';
+                });
+        });
+      });
+    </script>
+  </body>
+</html>
+"""
+    return Response(body=html, headers={'Content-Type': 'text/html'})
 
 app.run(debug=True, port=80)

--- a/include/lions/firewall/common.h
+++ b/include/lions/firewall/common.h
@@ -39,6 +39,21 @@ static inline uint32_t htonl(uint32_t n)
 #endif
 }
 
+/**
+ * Convert a 16 bit unsigned from network byte order to host byte order.
+ *
+ * @param n Integer represented in network byte order.
+ * @return Integer represented in host byte order.
+ */
+static inline uint16_t ntohs(uint16_t n)
+{
+#if BYTE_ORDER == BIG_ENDIAN
+    return n;
+#else
+    return (n & 0xff) << 8 | (n & 0xff00) >> 8;
+#endif
+}
+
 /* Subnet value of N means IPs must match on highest N bits. IP addresses are
 stored big-endian, so mask byte order must be swapped for subnet match. */
 #define subnet_mask(n) htonl((uint32_t)(0xffffffffUL << (32 - (n))))

--- a/include/lions/firewall/config.h
+++ b/include/lions/firewall/config.h
@@ -20,6 +20,8 @@
 #define FW_NUM_ARP_REQUESTER_CLIENTS 2
 #define FW_NUM_INTERFACES 2
 
+#define FW_FILTER_NUM_ACTIONS 4
+
 #define FW_DEBUG_OUTPUT 1
 
 typedef struct fw_connection_resource {
@@ -115,10 +117,18 @@ typedef struct fw_router_config {
     uint8_t num_filters;
 } fw_router_config_t;
 
+typedef struct fw_icmp_module_interface_config {
+    /* MAC address of interface */
+    uint8_t mac_addr[ETH_HWADDR_LEN];
+    /* IP address of interface */
+    uint32_t ip;
+    fw_connection_resource_t router;
+    fw_connection_resource_t filters[FW_MAX_FILTERS];
+    uint8_t num_filters;
+} fw_icmp_module_interface_config_t;
+
 typedef struct fw_icmp_module_config {
-    /* IP address of interfaces */
-    uint32_t ips[FW_NUM_INTERFACES];
-    fw_connection_resource_t routers[FW_NUM_INTERFACES];
+    fw_icmp_module_interface_config_t interfaces[FW_NUM_INTERFACES];
     uint8_t num_interfaces;
 } fw_icmp_module_config_t;
 
@@ -128,6 +138,7 @@ typedef struct fw_webserver_filter_config {
     uint8_t default_action;
     region_resource_t rules;
     uint16_t rules_capacity;
+    uint8_t actions[FW_FILTER_NUM_ACTIONS];
 } fw_webserver_filter_config_t;
 
 typedef struct fw_filter_config {
@@ -139,6 +150,7 @@ typedef struct fw_filter_config {
     region_resource_t internal_instances;
     region_resource_t external_instances;
     region_resource_t rule_id_bitmap;
+    fw_connection_resource_t icmp_module;
 } fw_filter_config_t;
 
 typedef struct fw_webserver_interface_config {

--- a/include/lions/firewall/filter.h
+++ b/include/lions/firewall/filter.h
@@ -30,24 +30,28 @@ typedef enum {
     FILTER_ERR_CLASH,
     /* rule id does not point to a valid entry, or is the default action rule id
     */
-    FILTER_ERR_INVALID_RULE_ID
+    FILTER_ERR_INVALID_RULE_ID,
+    /* unsupported action */
+    FILTER_ERR_UNSUPPORTED_ACTION
 } fw_filter_err_t;
 
 static const char *fw_filter_err_str[] = { "Ok.", "Out of memory error.", "Duplicate entry.", "Clashing entry.",
-                                           "Invalid rule ID." };
+                                           "Invalid rule ID.", "Unsupported action." };
 
 typedef enum {
     /* allow traffic */
     FILTER_ACT_ALLOW = 1,
     /* drop traffic */
-    FILTER_ACT_DROP = 2,
+	FILTER_ACT_DROP = 2,
+    /* reject traffic (send back icmp unreachable) */
+    FILTER_ACT_REJECT = 3,
     /* allow traffic, and additionally any return traffic */
-    FILTER_ACT_CONNECT = 3,
+    FILTER_ACT_CONNECT = 4,
     /* traffic is return traffic from a connect rule */
-    FILTER_ACT_ESTABLISHED
+    FILTER_ACT_ESTABLISHED = 5,
 } fw_action_t;
 
-static const char *fw_filter_action_str[] = { "No rule", "Allow", "Drop", "Connect", "Established" };
+static const char *fw_filter_action_str[] = { "No rule", "Allow", "Drop", "Reject", "Connect", "Established" };
 
 typedef struct fw_rule {
     /* action to be applied to traffic matching rule */

--- a/include/lions/firewall/icmp.h
+++ b/include/lions/firewall/icmp.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include <lions/firewall/ip.h>
+#include <lions/firewall/queue.h>
 
 /* ----------------- ICMP Protocol Definitions ---------------------------*/
 
@@ -38,6 +39,15 @@ typedef struct __attribute__((__packed__)) icmp_hdr {
 #define ICMP_ROUTER_SOLIT 10
 #define ICMP_ROUTER_SOLIT 10
 #define ICMP_TTL_EXCEED 11
+#define ICMP_PARAM_PROBLEM 12
+
+/* ICMP error types */
+#define ICMP_ERROR_TYPES_MASK ((1 << ICMP_DEST_UNREACHABLE) | \
+                               (1 << ICMP_SRC_QUENCH) | \
+                               (1 << ICMP_TTL_EXCEED) | \
+                               (1 << ICMP_PARAM_PROBLEM) | \
+                               (1 << ICMP_REDIRECT_MSG))
+
 
 /* ICMP destination unreachable sub-type codes */
 #define ICMP_DEST_NET_UNREACHABLE 0
@@ -52,19 +62,30 @@ typedef struct __attribute__((__packed__)) icmp_hdr {
 #define ICMP_NET_ADMIN_PROHIBITED 9
 #define ICMP_HOST_ADMIN_PROHIBITED 10
 
-/* ----------------- 3 - Destination Unreachable ---------------------------*/
+/* ICMP Time Exceeded sub-type codes */
+#define ICMP_TIME_EXCEEDED_TTL 0
+#define ICMP_TIME_EXCEEDED_FRAG 1
 
-/* Default number of bytes included from source packet in destination
-unreachable replies */
+/* ICMP Redirect sub-type codes */
+#define ICMP_REDIRECT_FOR_NET 0
+#define ICMP_REDIRECT_FOR_HOST 1
+#define ICMP_REDIRECT_FOR_TOS_NET 2
+#define ICMP_REDIRECT_FOR_TOS_HOST 3
 #define FW_ICMP_SRC_DATA_LEN 8
+#define FW_ICMP_ECHO_PAYLOAD_LEN 56
 
+/* Unified Offset for all ICMP sub-headers (Type-specific data) */
+#define ICMP_PAYLOAD_OFFSET (ICMP_HDR_OFFSET + ICMP_COMMON_HDR_LEN)
+
+/* ----------------- WIRE FORMATS (Packed for Network) --------------------------- */
+
+/* ----------------- 3 - ICMP DESTINATION UNREACHABLE ---------------------------*/
 typedef struct __attribute__((__packed__)) icmp_dest {
     /* unused, must be set to 0 */
     uint8_t unused;
     /* optional length of source packet in 32-bit words, or 0 */
     uint8_t len;
-    /* optional MTU of the next-hop network if source packet was too large, or 0
-    */
+    /* optional MTU of the next-hop network if source packet was too large, or 0 */
     uint16_t nexthop_mtu;
     /* IP header of source packet */
     ipv4_hdr_t ip_hdr;
@@ -72,24 +93,237 @@ typedef struct __attribute__((__packed__)) icmp_dest {
     uint8_t data[FW_ICMP_SRC_DATA_LEN];
 } icmp_dest_t;
 
-/* Offset of the start of the ICMP destination unreachable sub-header */
-#define ICMP_DEST_OFFSET (ICMP_HDR_OFFSET + ICMP_COMMON_HDR_LEN)
-
-/* Total length of ICMP destination unreachable header */
 #define ICMP_DEST_LEN (ICMP_COMMON_HDR_LEN + sizeof(icmp_dest_t))
 
-/* ----------------- Firewall Data Types ---------------------------*/
+/* ----------------- 5 - ICMP REDIRECT MSG ---------------------------*/
+typedef struct __attribute__((__packed__)) icmp_redirect {
+    /* IP Address of the new path */
+    uint32_t gateway_ip;
+    /* IP header of source packet */
+    ipv4_hdr_t ip_hdr;
+    /* First 8 bytes of data from source packet */
+    uint8_t data[FW_ICMP_SRC_DATA_LEN];
+} icmp_redirect_t;
+
+#define ICMP_REDIRECT_LEN (ICMP_COMMON_HDR_LEN + sizeof(icmp_redirect_t))
+
+/* ----------------- 8 - Echo Request / 0 - Echo Reply ---------------------------*/
+typedef struct __attribute__((__packed__)) icmp_echo {
+    /* Identifier to match requests with replies */
+    uint16_t id;
+    /* Sequence number */
+    uint16_t seq;
+    /* Payload data follows */
+    uint8_t data[FW_ICMP_ECHO_PAYLOAD_LEN];
+} icmp_echo_t;
+
+/* Total length of ICMP echo request/reply packet with maximum payload */
+#define ICMP_ECHO_LEN (ICMP_COMMON_HDR_LEN + sizeof(icmp_echo_t) + FW_ICMP_ECHO_PAYLOAD_LEN)
+
+/* ----------------- 11 - Time Exceeded ---------------------------*/
+typedef struct __attribute__((__packed__)) icmp_time_exceeded {
+    /* unused, must be set to 0 */
+    uint32_t unused;
+    /* IP header of source packet */
+    ipv4_hdr_t ip_hdr;
+    /* First 8 bytes of data from source packet */
+    uint8_t data[FW_ICMP_SRC_DATA_LEN];
+} icmp_time_exceeded_t;
+
+#define ICMP_TIME_EXCEEDED_LEN (ICMP_COMMON_HDR_LEN + sizeof(icmp_time_exceeded_t))
+
+/* ----------------- Firewall Data Types (Internal Use) --------------------------- */
+
+/* ICMP destination unreachable request data */
+typedef struct {
+    /* first 8 bytes of data from source packet */
+    uint8_t data[FW_ICMP_SRC_DATA_LEN];
+} icmp_req_dest_t;
+
+/* ICMP echo request/reply data */
+typedef struct {
+    /* Identifier to match requests with replies */
+    uint16_t echo_id;
+    /* Sequence number */
+    uint16_t echo_seq;
+    /* Payload length */
+    uint16_t payload_len;
+    /* Echo payload data */
+    uint8_t data[FW_ICMP_ECHO_PAYLOAD_LEN];
+} icmp_req_echo_t;
+
+/* ICMP time exceeded data */
+typedef struct {
+    /* first 8 bytes of data from source packet */
+    uint8_t data[FW_ICMP_SRC_DATA_LEN];
+} icmp_req_time_exceeded_t;
+
+/* ICMP redirect data */
+typedef struct {
+    /* new gateway IP address */
+    uint32_t gateway_ip;
+    /* first 8 bytes of data from source packet */
+    uint8_t data[FW_ICMP_SRC_DATA_LEN];
+} icmp_req_redirect_t;
 
 /* Data type of ICMP queues used to request transmission of ICMP packets */
 typedef struct icmp_req {
     /* type of ICMP packet to send */
     uint8_t type;
-    /* tode of ICMP packet to sent */
+    /* code of ICMP packet to send */
     uint8_t code;
     /* ethernet header of request source packet */
     eth_hdr_t eth_hdr;
     /* header of source IP packet */
     ipv4_hdr_t ip_hdr;
-    /* first 8 bytes of data from source packet */
-    uint8_t data[FW_ICMP_SRC_DATA_LEN];
+    /* Type-specific data */
+    union {
+        icmp_req_dest_t dest;
+        icmp_req_echo_t echo;
+        icmp_req_time_exceeded_t time_exceeded;
+        icmp_req_redirect_t redirect;
+    };
 } icmp_req_t;
+
+/**
+ * Check if ICMP type is an error message that should not trigger redirects.
+ * Per RFC 1812, redirects should not be sent for ICMP error messages.
+ *
+ * @param type ICMP type value
+ *
+ * @return true if type is an ICMP error message, false otherwise
+ */
+static inline bool icmp_is_error_message(uint8_t type)
+{
+    return (type == ICMP_DEST_UNREACHABLE ||
+            type == ICMP_REDIRECT_MSG ||
+            type == ICMP_SRC_QUENCH ||
+            type == ICMP_TTL_EXCEED ||
+            type == ICMP_PARAM_PROBLEM);
+}
+
+
+
+/**
+ * Enqueue an ICMP request to send back to the source.
+ * This is a generic helper for destination unreachable, time exceeded, etc.
+ *
+ * @param icmp_queue Pointer to the ICMP queue to enqueue the request.
+ * @param type ICMP type (e.g., ICMP_DEST_UNREACHABLE, ICMP_TTL_EXCEED).
+ * @param code ICMP code (e.g., ICMP_DEST_PORT_UNREACHABLE).
+ * @param pkt_vaddr Virtual address of the packet data.
+ *
+ * @return true on success, false if the queue is full.
+ */
+static inline bool icmp_enqueue_error(fw_queue_t *icmp_queue, uint8_t type, uint8_t code, uintptr_t pkt_vaddr)
+{
+    icmp_req_t req = {0};
+    req.type = type;
+    req.code = code;
+
+    /* Copy ethernet header into ICMP request */
+    memcpy(&req.eth_hdr, (void *)pkt_vaddr, ETH_HDR_LEN);
+
+    /* Copy IP header into ICMP request */
+    ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
+    memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
+
+    /* Copy first bytes of data if applicable */
+    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(ip_hdr->tot_len) - IPV4_HDR_LEN_MIN);
+    memcpy(req.dest.data, (void *)(pkt_vaddr + IPV4_HDR_OFFSET + IPV4_HDR_LEN_MIN), to_copy);
+
+    return fw_enqueue(icmp_queue, &req) == 0;
+}
+
+/**
+ * Enqueue an ICMP echo reply request.
+ *
+ * @param icmp_queue Pointer to the ICMP queue to enqueue the request.
+ * @param pkt_vaddr Virtual address of the packet data.
+ *
+ * @return true on success, false if the queue is full.
+ */
+static inline bool icmp_enqueue_echo_reply(fw_queue_t *icmp_queue, uintptr_t pkt_vaddr)
+{
+    ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
+
+    /* Extract echo id and sequence from the ICMP echo header */
+    icmp_echo_t *echo_hdr = (icmp_echo_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET);
+    uint16_t echo_id = ntohs(echo_hdr->id);
+    uint16_t echo_seq = ntohs(echo_hdr->seq);
+
+    /* Calculate payload length */
+    uint16_t icmp_total_len = htons(ip_hdr->tot_len) - ipv4_header_length(ip_hdr);
+    uint16_t payload_len = icmp_total_len - ICMP_COMMON_HDR_LEN - (sizeof(icmp_echo_t) - FW_ICMP_ECHO_PAYLOAD_LEN);
+    if (payload_len > FW_ICMP_ECHO_PAYLOAD_LEN) {
+        payload_len = FW_ICMP_ECHO_PAYLOAD_LEN;
+    }
+
+    icmp_req_t req = {0};
+    req.type = ICMP_ECHO_REPLY;
+    req.code = 0;
+    req.echo.echo_id = echo_id;
+    req.echo.echo_seq = echo_seq;
+    req.echo.payload_len = payload_len;
+
+    /* Copy ethernet header into ICMP request */
+    memcpy(&req.eth_hdr, (void *)pkt_vaddr, ETH_HDR_LEN);
+
+    /* Copy IP header into ICMP request */
+    memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
+
+    /* Copy payload */
+    uint8_t *payload_data = (uint8_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET + (sizeof(icmp_echo_t) - FW_ICMP_ECHO_PAYLOAD_LEN));
+    memcpy(req.echo.data, payload_data, payload_len);
+
+    return fw_enqueue(icmp_queue, &req) == 0;
+}
+
+/**
+ * Enqueue an ICMP redirect request.
+ *
+ * @param icmp_queue Pointer to the ICMP queue to enqueue the request.
+ * @param code ICMP redirect code (e.g., ICMP_REDIRECT_FOR_HOST).
+ * @param pkt_vaddr Virtual address of the packet data.
+ * @param gateway_ip IP address of the gateway to redirect to.
+ *
+ * @return 0 on success, non-zero on failure.
+ */
+static inline int icmp_enqueue_redirect(fw_queue_t *icmp_queue, uint8_t code, uintptr_t pkt_vaddr, uint32_t gateway_ip)
+{
+    icmp_req_t req = {0};
+    req.type = ICMP_REDIRECT_MSG;
+    req.code = code;
+
+    /* Copy ethernet header into ICMP request */
+    memcpy(&req.eth_hdr, (void *)pkt_vaddr, ETH_HDR_LEN);
+
+    /* Copy IP header into ICMP request */
+    ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
+    memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
+
+    /* Set gateway IP and copy first bytes of data */
+    req.redirect.gateway_ip = gateway_ip;
+    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(ip_hdr->tot_len) - IPV4_HDR_LEN_MIN);
+    memcpy(req.redirect.data, (void *)(pkt_vaddr + IPV4_HDR_OFFSET + IPV4_HDR_LEN_MIN), to_copy);
+
+    return fw_enqueue(icmp_queue, &req);
+}
+
+/**
+ * @brief Checks if an ICMP message type is an error type.
+ *
+ * Determines whether the given ICMP type represents an error message by
+ * checking against a bitmask of known error types.
+ *
+ * @param type The ICMP message type to check.
+ *
+ * @return true if the type is an ICMP error type, false otherwise.
+ */
+static inline int icmp_is_error_type(int type)
+{
+    if ( (1 << type) & ICMP_ERROR_TYPES_MASK) {
+        return true;
+    }
+    return false;
+}

--- a/include/lions/firewall/routing.h
+++ b/include/lions/firewall/routing.h
@@ -56,6 +56,7 @@ typedef enum {
 /* PP call parameters for webserver to call router and update routing table */
 #define FW_ADD_ROUTE 0
 #define FW_DEL_ROUTE 1
+#define FW_SET_PING_RESPONSE 2
 
 typedef enum { ROUTER_ARG_ROUTE_ID = 0, ROUTER_ARG_IP, ROUTER_ARG_SUBNET, ROUTER_ARG_NEXT_HOP } fw_router_args_t;
 


### PR DESCRIPTION
Issue #194 

1. Added ICMP ping support for the firewall by creating `enqueue_icmp_ping` in `routing.c`. The webservre can toggle the supprt for each interface.
2. Add support for UDP Reject. An ICMP `Destination Unreachable` is sent when rejected.