### PR TITLE
Firewall: Allow firewall memory region and data structure sizes to be recalculated in the metaprogram

### DIFF
--- a/examples/firewall/meta.py
+++ b/examples/firewall/meta.py
@@ -181,6 +181,9 @@ class FirewallMemoryRegions:
 
     # Call to recalculate size after data structure update
     def update_size(self):
+        for structure in self.data_structures:
+            structure.update_size()
+
         self.min_size = self.size_formula(self.data_structures)
         if not self.min_size:
             raise Exception(


### PR DESCRIPTION
This allows firewall data structure/memory region sizes to be dependent on constants that are calculated as the metaprogram runs. In particular, this issue arose when the capacity of a table was dependent on the total number of filters in the system.