### PR TITLE
Refactor the meta program.

### DIFF
--- a/examples/firewall/filters/icmp_filter.c
+++ b/examples/firewall/filters/icmp_filter.c
@@ -212,8 +212,8 @@ void init(void)
     fw_queue_init(&router_queue, filter_config.router.queue.vaddr, sizeof(net_buff_desc_t),
                   filter_config.router.capacity);
 
-    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.rule_id_bitmap.vaddr,
-                         filter_config.webserver.rules_capacity, filter_config.internal_instances.vaddr,
+    fw_filter_state_init(&filter_state, filter_config.rules.vaddr, filter_config.rule_id_bitmap.vaddr,
+                         filter_config.rules_capacity, filter_config.internal_instances.vaddr,
                          filter_config.external_instances.vaddr, filter_config.instances_capacity,
-                         (fw_action_t)filter_config.webserver.default_action);
+                         filter_config.default_rule, filter_config.initial_rules, filter_config.num_initial_rules);
 }

--- a/examples/firewall/filters/tcp_filter.c
+++ b/examples/firewall/filters/tcp_filter.c
@@ -214,8 +214,8 @@ void init(void)
     fw_queue_init(&router_queue, filter_config.router.queue.vaddr, sizeof(net_buff_desc_t),
                   filter_config.router.capacity);
 
-    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.rule_id_bitmap.vaddr,
-                         filter_config.webserver.rules_capacity, filter_config.internal_instances.vaddr,
+    fw_filter_state_init(&filter_state, filter_config.rules.vaddr, filter_config.rule_id_bitmap.vaddr,
+                         filter_config.rules_capacity, filter_config.internal_instances.vaddr,
                          filter_config.external_instances.vaddr, filter_config.instances_capacity,
-                         (fw_action_t)filter_config.webserver.default_action);
+                         filter_config.default_rule, filter_config.initial_rules, filter_config.num_initial_rules);
 }

--- a/examples/firewall/filters/udp_filter.c
+++ b/examples/firewall/filters/udp_filter.c
@@ -214,8 +214,8 @@ void init(void)
     fw_queue_init(&router_queue, filter_config.router.queue.vaddr, sizeof(net_buff_desc_t),
                   filter_config.router.capacity);
 
-    fw_filter_state_init(&filter_state, filter_config.webserver.rules.vaddr, filter_config.rule_id_bitmap.vaddr,
-                         filter_config.webserver.rules_capacity, filter_config.internal_instances.vaddr,
+    fw_filter_state_init(&filter_state, filter_config.rules.vaddr, filter_config.rule_id_bitmap.vaddr,
+                         filter_config.rules_capacity, filter_config.internal_instances.vaddr,
                          filter_config.external_instances.vaddr, filter_config.instances_capacity,
-                         (fw_action_t)filter_config.webserver.default_action);
+                         filter_config.default_rule, filter_config.initial_rules, filter_config.num_initial_rules);
 }

--- a/examples/firewall/firewall.mk
+++ b/examples/firewall/firewall.mk
@@ -168,10 +168,10 @@ $(SYSTEM_FILE): $(METAPROGRAM) $(IMAGES) $(DTB) $(CHECK_FLAGS_BOARD_MD5)
 	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_icmp_filter1.data icmp_filter1.elf
 	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_udp_filter1.data udp_filter1.elf
 	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_tcp_filter1.data tcp_filter1.elf
-	$(OBJCOPY) --update-section .net_client_config=net_data1/net_client_micropython.data micropython.elf
+	$(OBJCOPY) --update-section .net_client_config=net_data0/net_client_micropython.data micropython.elf
 	$(OBJCOPY) --update-section .int_net_client_config=net_data1/net_client_icmp_module.data icmp_module.elf
 
-	$(OBJCOPY) --update-section .lib_sddf_lwip_config=net_data1/lib_sddf_lwip_config_micropython.data micropython.elf
+	$(OBJCOPY) --update-section .lib_sddf_lwip_config=net_data0/lib_sddf_lwip_config_micropython.data micropython.elf
 
 	$(OBJCOPY) --update-section .serial_client_config=serial_client_arp_responder1.data arp_responder1.elf
 	$(OBJCOPY) --update-section .serial_client_config=serial_client_arp_requester1.data arp_requester1.elf

--- a/examples/firewall/specs.py
+++ b/examples/firewall/specs.py
@@ -1,0 +1,584 @@
+# Copyright 2025, UNSW SPDX-License-Identifier: BSD-2-Clause
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict, Any, Tuple
+from sdfgen import SystemDescription, Sddf, DeviceTree
+from config_structs import (
+    RegionResource,
+    DeviceRegionResource,
+    FwConnectionResource,
+    FwArpConnection,
+    FwDataConnectionResource,
+)
+
+ProtectionDomain = SystemDescription.ProtectionDomain
+MemoryRegion = SystemDescription.MemoryRegion
+Map = SystemDescription.Map
+Channel = SystemDescription.Channel
+
+
+def fw_map(pd, mr, perms):
+    """Map a memory region into a protection domain, return the Map."""
+    pd_map = Map(mr, pd.get_map_vaddr(mr), perms=perms)
+    pd.add_map(pd_map)
+    return pd_map
+
+
+def fw_resource(pd_map, size):
+    """Create a RegionResource from a Map and size."""
+    return RegionResource(pd_map.vaddr, size)
+
+
+def fw_device_resource(pd_map, mr):
+    """Create a DeviceRegionResource from a Map and its physical MR."""
+    return DeviceRegionResource(fw_resource(pd_map, mr.size), mr.paddr)
+
+
+@dataclass
+class TopologyEdge:
+    """Descriptor for one edge in the topology graph."""
+
+    src_name: str
+    dst_name: str
+    category: str
+    bidirectional: bool = False
+    channel_label: str = ""  # e.g., "ch=3/4"
+    queue_perms: str = "rw"
+    extra_perms: str = ""  # e.g., "rw/r" for DMA
+
+
+@dataclass
+class ConnectionSpec:
+    """A point-to-point connection (queue + channel) between two PDs."""
+
+    name: str
+    sdf: SystemDescription
+    src_pd: ProtectionDomain
+    dst_pd: ProtectionDomain
+    capacity: int
+    queue_region_size: int
+    name_suffix: str = ""
+    category: str = ""
+    interface_index: Optional[int] = None
+    description: str = ""
+    _src_resource: Optional[Any] = field(default=None, repr=False)
+    _dst_resource: Optional[Any] = field(default=None, repr=False)
+    _channel_id_src: Optional[int] = field(default=None, repr=False)
+    _channel_id_dst: Optional[int] = field(default=None, repr=False)
+
+    def create(self) -> Tuple[Any, Any]:
+        """Creates a queue MR, maps into both PDs, and creates a communication channel."""
+        queue_name = (
+            "fw_queue_" + self.src_pd.name + "_" + self.dst_pd.name + self.name_suffix
+        )
+        queue = MemoryRegion(self.sdf, queue_name, self.queue_region_size)
+        self.sdf.add_mr(queue)
+
+        src_map = fw_map(self.src_pd, queue, "rw")
+        src_region = fw_resource(src_map, self.queue_region_size)
+
+        dst_map = fw_map(self.dst_pd, queue, "rw")
+        dst_region = fw_resource(dst_map, self.queue_region_size)
+
+        ch = Channel(self.src_pd, self.dst_pd)
+        self.sdf.add_channel(ch)
+
+        self._channel_id_src = ch.pd_a_id
+        self._channel_id_dst = ch.pd_b_id
+        self._src_resource = FwConnectionResource(src_region, self.capacity, ch.pd_a_id)
+        self._dst_resource = FwConnectionResource(dst_region, self.capacity, ch.pd_b_id)
+
+        return (self._src_resource, self._dst_resource)
+
+    @property
+    def src_resource(self) -> Any:
+        assert self._src_resource is not None, (
+            f"ConnectionSpec '{self.name}' not yet created"
+        )
+        return self._src_resource
+
+    @property
+    def dst_resource(self) -> Any:
+        assert self._dst_resource is not None, (
+            f"ConnectionSpec '{self.name}' not yet created"
+        )
+        return self._dst_resource
+
+    def label(self) -> str:
+        return f"Connection({self.name}: {self.src_pd.name} -> {self.dst_pd.name}, cap={self.capacity})"
+
+    def topology_edges(self) -> List[TopologyEdge]:
+        ch = ""
+        if self._channel_id_src is not None:
+            ch = f"ch={self._channel_id_src}/{self._channel_id_dst}"
+        return [
+            TopologyEdge(
+                src_name=self.src_pd.name,
+                dst_name=self.dst_pd.name,
+                category=self.category,
+                channel_label=ch,
+            )
+        ]
+
+
+@dataclass
+class ArpConnectionSpec:
+    """Bidirectional ARP request/response connection (two queues + one channel)."""
+
+    name: str
+    sdf: SystemDescription
+    pd1: ProtectionDomain
+    pd2: ProtectionDomain
+    capacity: int
+    queue_region_size: int
+    category: str = "arp"
+    interface_index: Optional[int] = None
+    description: str = ""
+    _pd1_resource: Optional[Any] = field(default=None, repr=False)
+    _pd2_resource: Optional[Any] = field(default=None, repr=False)
+    _channel_id_src: Optional[int] = field(default=None, repr=False)
+    _channel_id_dst: Optional[int] = field(default=None, repr=False)
+
+    def create(self) -> Tuple[Any, Any]:
+        # Request queue
+        req_queue_name = "fw_req_queue_" + self.pd1.name + "_" + self.pd2.name
+        req_queue = MemoryRegion(self.sdf, req_queue_name, self.queue_region_size)
+        self.sdf.add_mr(req_queue)
+        pd1_req_map = fw_map(self.pd1, req_queue, "rw")
+        pd1_req_region = fw_resource(pd1_req_map, self.queue_region_size)
+        pd2_req_map = fw_map(self.pd2, req_queue, "rw")
+        pd2_req_region = fw_resource(pd2_req_map, self.queue_region_size)
+
+        # Response queue
+        res_queue_name = "fw_res_queue_" + self.pd1.name + "_" + self.pd2.name
+        res_queue = MemoryRegion(self.sdf, res_queue_name, self.queue_region_size)
+        self.sdf.add_mr(res_queue)
+        pd1_res_map = fw_map(self.pd1, res_queue, "rw")
+        pd1_res_region = fw_resource(pd1_res_map, self.queue_region_size)
+        pd2_res_map = fw_map(self.pd2, res_queue, "rw")
+        pd2_res_region = fw_resource(pd2_res_map, self.queue_region_size)
+
+        ch = Channel(self.pd1, self.pd2)
+        self.sdf.add_channel(ch)
+
+        self._channel_id_src = ch.pd_a_id
+        self._channel_id_dst = ch.pd_b_id
+        self._pd1_resource = FwArpConnection(
+            pd1_req_region, pd1_res_region, self.capacity, ch.pd_a_id
+        )
+        self._pd2_resource = FwArpConnection(
+            pd2_req_region, pd2_res_region, self.capacity, ch.pd_b_id
+        )
+        return (self._pd1_resource, self._pd2_resource)
+
+    @property
+    def pd1_resource(self) -> Any:
+        assert self._pd1_resource is not None, (
+            f"ArpConnectionSpec '{self.name}' not yet created"
+        )
+        return self._pd1_resource
+
+    @property
+    def pd2_resource(self) -> Any:
+        assert self._pd2_resource is not None, (
+            f"ArpConnectionSpec '{self.name}' not yet created"
+        )
+        return self._pd2_resource
+
+    def label(self) -> str:
+        return f"ArpConnection({self.name}: {self.pd1.name} <-> {self.pd2.name})"
+
+    def topology_edges(self) -> List[TopologyEdge]:
+        ch = ""
+        if self._channel_id_src is not None:
+            ch = f"ch={self._channel_id_src}/{self._channel_id_dst}"
+        return [
+            TopologyEdge(
+                src_name=self.pd1.name,
+                dst_name=self.pd2.name,
+                category=self.category,
+                bidirectional=True,
+                channel_label=ch,
+            )
+        ]
+
+
+@dataclass
+class DataConnectionSpec:
+    """Data connection: queue + channel + DMA region mapping."""
+
+    name: str
+    sdf: SystemDescription
+    src_pd: ProtectionDomain
+    dst_pd: ProtectionDomain
+    capacity: int
+    queue_size: int
+    data_mr: Any  # DMA MemoryRegion
+    src_data_perms: str
+    dst_data_perms: str
+    name_suffix: str = ""
+    category: str = "data"
+    interface_index: Optional[int] = None
+    description: str = ""
+    _src_resource: Optional[Any] = field(default=None, repr=False)
+    _dst_resource: Optional[Any] = field(default=None, repr=False)
+    _conn_spec: Optional[ConnectionSpec] = field(default=None, repr=False)
+
+    def create(self) -> Tuple[Any, Any]:
+        self._conn_spec = ConnectionSpec(
+            name=self.name + "_queue",
+            sdf=self.sdf,
+            src_pd=self.src_pd,
+            dst_pd=self.dst_pd,
+            capacity=self.capacity,
+            queue_region_size=self.queue_size,
+            name_suffix=self.name_suffix,
+            category=self.category,
+            interface_index=self.interface_index,
+        )
+        connection = self._conn_spec.create()
+        src_data_map = fw_map(self.src_pd, self.data_mr, self.src_data_perms)
+        data_region1 = fw_device_resource(src_data_map, self.data_mr)
+        dst_data_map = fw_map(self.dst_pd, self.data_mr, self.dst_data_perms)
+        data_region2 = fw_device_resource(dst_data_map, self.data_mr)
+        self._src_resource = FwDataConnectionResource(connection[0], data_region1)
+        self._dst_resource = FwDataConnectionResource(connection[1], data_region2)
+        return (self._src_resource, self._dst_resource)
+
+    @property
+    def src_resource(self) -> Any:
+        assert self._src_resource is not None, (
+            f"DataConnectionSpec '{self.name}' not yet created"
+        )
+        return self._src_resource
+
+    @property
+    def dst_resource(self) -> Any:
+        assert self._dst_resource is not None, (
+            f"DataConnectionSpec '{self.name}' not yet created"
+        )
+        return self._dst_resource
+
+    def label(self) -> str:
+        return f"DataConnection({self.name}: {self.src_pd.name} -> {self.dst_pd.name})"
+
+    def topology_edges(self) -> List[TopologyEdge]:
+        ch = ""
+        if self._conn_spec and self._conn_spec._channel_id_src is not None:
+            ch = f"ch={self._conn_spec._channel_id_src}/{self._conn_spec._channel_id_dst}"
+        return [
+            TopologyEdge(
+                src_name=self.src_pd.name,
+                dst_name=self.dst_pd.name,
+                category=self.category,
+                channel_label=ch,
+                extra_perms=f"{self.src_data_perms}/{self.dst_data_perms}",
+            )
+        ]
+
+
+@dataclass
+class SharedRegionSpec:
+    """Shared memory region between two PDs with different permissions."""
+
+    name: str
+    sdf: SystemDescription
+    size: int
+    owner_pd: ProtectionDomain
+    peer_pd: ProtectionDomain
+    owner_perms: str = "rw"
+    peer_perms: str = "r"
+    category: str = ""
+    interface_index: Optional[int] = None
+    description: str = ""
+    _owner_view: Optional[Any] = field(default=None, repr=False)
+    _peer_view: Optional[Any] = field(default=None, repr=False)
+
+    def map(self) -> Tuple[Any, Any]:
+        region_name = self.name + "_" + self.owner_pd.name + "_" + self.peer_pd.name
+        mr = MemoryRegion(self.sdf, region_name, self.size)
+        self.sdf.add_mr(mr)
+        owner_map = fw_map(self.owner_pd, mr, self.owner_perms)
+        self._owner_view = fw_resource(owner_map, self.size)
+        peer_map = fw_map(self.peer_pd, mr, self.peer_perms)
+        self._peer_view = fw_resource(peer_map, self.size)
+        return (self._owner_view, self._peer_view)
+
+    @property
+    def owner_view(self) -> Any:
+        assert self._owner_view is not None, (
+            f"SharedRegionSpec '{self.name}' not yet mapped"
+        )
+        return self._owner_view
+
+    @property
+    def peer_view(self) -> Any:
+        assert self._peer_view is not None, (
+            f"SharedRegionSpec '{self.name}' not yet mapped"
+        )
+        return self._peer_view
+
+    def label(self) -> str:
+        return f"SharedRegion({self.name}: {self.owner_pd.name}[{self.owner_perms}] <-> {self.peer_pd.name}[{self.peer_perms}])"
+
+    def topology_mappings(self) -> List[Tuple[str, str]]:
+        return [
+            (self.owner_pd.name, self.owner_perms),
+            (self.peer_pd.name, self.peer_perms),
+        ]
+
+
+@dataclass
+class PrivateRegionSpec:
+    """A private memory region owned by a single PD."""
+
+    name: str
+    sdf: SystemDescription
+    size: int
+    pd: ProtectionDomain
+    perms: str = "rw"
+    category: str = ""
+    interface_index: Optional[int] = None
+    description: str = ""
+    _resource: Optional[Any] = field(default=None, repr=False)
+
+    def create(self) -> Any:
+        region_name = self.name + "_" + self.pd.name
+        mr = MemoryRegion(self.sdf, region_name, self.size)
+        self.sdf.add_mr(mr)
+        pd_map = fw_map(self.pd, mr, self.perms)
+        self._resource = fw_resource(pd_map, self.size)
+        return self._resource
+
+    @property
+    def resource(self) -> Any:
+        assert self._resource is not None, (
+            f"PrivateRegionSpec '{self.name}' not yet created"
+        )
+        return self._resource
+
+    def label(self) -> str:
+        return f"PrivateRegion({self.name}: {self.pd.name}[{self.perms}])"
+
+    def topology_mappings(self) -> List[Tuple[str, str]]:
+        return [(self.pd.name, self.perms)]
+
+
+@dataclass
+class MappedRegionSpec:
+    """An existing memory region mapped into a PD."""
+
+    name: str
+    mr: Any  # existing MemoryRegion
+    pd: ProtectionDomain
+    perms: str = "rw"
+    size: int = 0  # override size (if different from mr.size)
+    category: str = ""
+    interface_index: Optional[int] = None
+    description: str = ""
+    _resource: Optional[Any] = field(default=None, repr=False)
+
+    def map(self) -> Any:
+        region_size = self.size if self.size else self.mr.size
+        pd_map = fw_map(self.pd, self.mr, self.perms)
+        self._resource = fw_resource(pd_map, region_size)
+        return self._resource
+
+    @property
+    def resource(self) -> Any:
+        assert self._resource is not None, (
+            f"MappedRegionSpec '{self.name}' not yet mapped"
+        )
+        return self._resource
+
+    def label(self) -> str:
+        return f"MappedRegion({self.name}: {self.pd.name}[{self.perms}])"
+
+
+@dataclass
+class TxActiveClient:
+    """Connection carrying routed packets into this interface's TX virtualiser."""
+
+    src_interface_index: int
+    resource: FwDataConnectionResource
+
+
+@dataclass
+class TxFreeClient:
+    """Buffer return path from this interface's TX virtualiser back to a source interface's RX virtualiser."""
+
+    src_interface_index: int
+    resource: FwDataConnectionResource
+
+
+@dataclass
+class OutboundConnection:
+    """Router's outbound data path from this interface toward a destination interface's TX virtualiser."""
+
+    dest_interface_index: int
+    resource: FwDataConnectionResource
+
+
+@dataclass
+class NetEdge:
+    """Lightweight representation of sDDF Net wiring for topology tracking."""
+
+    src_pd: ProtectionDomain
+    dst_pd: ProtectionDomain
+    label: str = ""
+    bidirectional: bool = True
+    interface_index: Optional[int] = None
+
+
+@dataclass
+class InterfaceWiring:
+    """Named wiring for a single network interface."""
+
+    interface: "NetworkInterface"
+
+    # Named config slots
+    rx_virt_config: Optional[Any] = None
+    tx_virt_config: Optional[Any] = None
+    arp_requester_config: Optional[Any] = None
+    arp_responder_config: Optional[Any] = None
+    filter_configs: Dict[int, Any] = field(default_factory=dict)  # protocol -> config
+
+    # Named Spec objects (ConnectionSpec, ArpConnectionSpec, DataConnectionSpec, SharedRegionSpec)
+    connections: Dict[str, Any] = field(default_factory=dict)
+    regions: Dict[str, Any] = field(default_factory=dict)
+
+    outbound_connections: List[OutboundConnection] = field(default_factory=list)
+    tx_active_clients: List[TxActiveClient] = field(default_factory=list)
+    tx_free_clients: List[TxFreeClient] = field(default_factory=list)
+    net_edges: List[NetEdge] = field(default_factory=list)
+
+    def configs_iter(self):
+        """Yield (pd, config) for serialization."""
+        if self.rx_virt_config:
+            yield (self.interface.rx_virt, self.rx_virt_config)
+        if self.tx_virt_config:
+            yield (self.interface.tx_virt, self.tx_virt_config)
+        if self.arp_requester_config:
+            yield (self.interface.arp_requester, self.arp_requester_config)
+        if self.arp_responder_config:
+            yield (self.interface.arp_responder, self.arp_responder_config)
+        for proto, cfg in self.filter_configs.items():
+            yield (self.interface.filters[proto], cfg)
+
+    def all_pds(self) -> List[Tuple[ProtectionDomain, str]]:
+        """Return all (pd, role_label) pairs for graph node rendering."""
+        pds = []
+        if getattr(self.interface, "router", None):
+            pds.append((self.interface.router, "Router"))
+        if self.interface.driver:
+            pds.append((self.interface.driver, "Driver"))
+        if self.interface.rx_virt:
+            pds.append((self.interface.rx_virt, "RX Virt"))
+        if self.interface.tx_virt:
+            pds.append((self.interface.tx_virt, "TX Virt"))
+        if self.interface.arp_requester:
+            pds.append((self.interface.arp_requester, "ARP Req"))
+        if self.interface.arp_responder:
+            pds.append((self.interface.arp_responder, "ARP Resp"))
+        proto_names = {0x01: "ICMP", 0x06: "TCP", 0x11: "UDP"}
+        for proto, pd in self.interface.filters.items():
+            pds.append((pd, f"{proto_names.get(proto, hex(proto))} Filter"))
+        return pds
+
+
+class TrackedNet:
+    """Wrapper around Sddf.Net to record net wiring edges for topology tracking."""
+
+    def __init__(
+        self,
+        sdf_obj: SystemDescription,
+        ethernet_node: DeviceTree.Node,
+        driver: ProtectionDomain,
+        virt_tx: ProtectionDomain,
+        virt_rx: ProtectionDomain,
+        rx_dma_region: Optional[MemoryRegion],
+        *,
+        interface_index: int,
+        wiring: Optional[InterfaceWiring] = None,
+    ):
+        self._net = Sddf.Net(
+            sdf_obj, ethernet_node, driver, virt_tx, virt_rx, rx_dma_region
+        )
+        self._obj = self._net._obj
+        self._driver = driver
+        self._virt_tx = virt_tx
+        self._virt_rx = virt_rx
+        self._interface_index = interface_index
+        self._edge_sink = wiring.net_edges if wiring else None
+        self._edge_keys = set()
+
+        self._add_edge(self._driver, self._virt_rx, "driver<->virt_rx")
+        self._add_edge(self._driver, self._virt_tx, "driver<->virt_tx")
+
+    def _edge_key(
+        self,
+        src: ProtectionDomain,
+        dst: ProtectionDomain,
+        label: str,
+        bidirectional: bool,
+    ) -> tuple:
+        if bidirectional:
+            names = tuple(sorted((src.name, dst.name)))
+        else:
+            names = (src.name, dst.name)
+        return (names, label, bidirectional, self._interface_index)
+
+    def _add_edge(
+        self,
+        src: ProtectionDomain,
+        dst: ProtectionDomain,
+        label: str,
+        *,
+        bidirectional: bool = True,
+    ) -> None:
+        if self._edge_sink is None:
+            return
+        key = self._edge_key(src, dst, label, bidirectional)
+        if key in self._edge_keys:
+            return
+        self._edge_keys.add(key)
+        self._edge_sink.append(
+            NetEdge(
+                src_pd=src,
+                dst_pd=dst,
+                label=label,
+                bidirectional=bidirectional,
+                interface_index=self._interface_index,
+            )
+        )
+
+    def add_client_with_copier(
+        self,
+        client: ProtectionDomain,
+        copier: Optional[ProtectionDomain] = None,
+        *,
+        mac_addr: Optional[str] = None,
+        rx: Optional[bool] = None,
+        tx: Optional[bool] = None,
+    ) -> None:
+        rx_enabled = True if rx is None else bool(rx)
+        tx_enabled = True if tx is None else bool(tx)
+
+        if rx_enabled:
+            if copier is None:
+                self._add_edge(self._virt_rx, client, "virt_rx<->client")
+            else:
+                self._add_edge(self._virt_rx, copier, "virt_rx<->copier")
+                self._add_edge(copier, client, "copier<->client")
+
+        if tx_enabled:
+            self._add_edge(self._virt_tx, client, "virt_tx<->client")
+
+        self._net.add_client_with_copier(
+            client, copier, mac_addr=mac_addr, rx=rx, tx=tx
+        )
+
+    def connect(self) -> bool:
+        return self._net.connect()
+
+    def serialise_config(self, output_dir: str) -> bool:
+        return self._net.serialise_config(output_dir)

--- a/examples/firewall/topology.py
+++ b/examples/firewall/topology.py
@@ -1,0 +1,355 @@
+# Copyright 2025, UNSW SPDX-License-Identifier: BSD-2-Clause
+from typing import Dict, Any
+
+EDGE_STYLES = {
+    "data": {"color": "#2196F3", "penwidth": "2.0"},
+    "buffer_return": {"color": "#9E9E9E"},
+    "arp": {"color": "#FF9800", "penwidth": "1.5"},
+    "filter": {"color": "#F44336", "penwidth": "1.5"},
+    "icmp": {"color": "#9C27B0", "penwidth": "1.5"},
+    "sddf_net": {"color": "#607D8B"},
+}
+
+REGION_STYLES = {
+    "arp_cache": {"fillcolor": "#FFF3E0"},
+    "routing_table": {"fillcolor": "#E8F5E9"},
+    "filter_rules": {"fillcolor": "#FFEBEE"},
+    "filter_instances": {"fillcolor": "#FBE9E7"},
+    "arp_packet_queue": {"fillcolor": "#FFF8E1"},
+    "rule_bitmap": {"fillcolor": "#F3E5F5"},
+    "dma_buffer": {"fillcolor": "#E0F7FA"},
+}
+
+SHOW_NODE_LABELS = True
+SHOW_EDGE_LABELS = True
+SHOW_EDGE_PERMS = False
+SHOW_LEGEND = True
+
+QUEUE_PERMS_LABEL = "rw"
+
+
+def _collect_all_connections(builder) -> Dict[str, Any]:
+    """Collect all ConnectionSpec/ArpConnectionSpec/DataConnectionSpec objects."""
+    conns = dict(builder._global_connections)
+    for iface in builder.interfaces:
+        for name, spec in iface.wiring.connections.items():
+            conns[f"iface{iface.index}_{name}"] = spec
+    return conns
+
+
+def _collect_all_regions(builder) -> Dict[str, Any]:
+    """Collect all SharedRegionSpec objects."""
+    regions = dict(builder._global_regions)
+    for iface in builder.interfaces:
+        for name, spec in iface.wiring.regions.items():
+            regions[f"iface{iface.index}_{name}"] = spec
+    return regions
+
+
+def _collect_all_net_edges(builder):
+    """Collect inferred sDDF Net edges from interface wiring."""
+    edges = []
+    for iface in builder.interfaces:
+        if hasattr(iface.wiring, "net_edges"):
+            edges.extend(iface.wiring.net_edges)
+    return edges
+
+
+def generate_topology_dot(builder) -> str:
+    """Generate a graphviz DOT string from all Spec objects."""
+    lines = ["digraph firewall_topology {"]
+    lines.append("    rankdir=LR;")
+    lines.append("    graph [overlap=false, splines=true, nodesep=0.4, ranksep=0.6, size=\"11,8.5!\", ratio=fill];")
+    lines.append('    node [shape=box, style=filled, fillcolor="#E3F2FD"];')
+    lines.append("    edge [fontsize=9, labelfloat=true];")
+    lines.append("")
+    label_node_counter = 0
+
+    def _emit_edge(
+        src: str,
+        dst: str,
+        *,
+        label: str = "",
+        attr_str: str = "",
+        dir_val: str = "",
+        arrowhead: str = "",
+        arrowtail: str = "",
+    ) -> None:
+        attrs = []
+        if label:
+            attrs.append(f'label="{label}"')
+        if dir_val:
+            attrs.append(f"dir={dir_val}")
+        if arrowhead:
+            attrs.append(f"arrowhead={arrowhead}")
+        if arrowtail:
+            attrs.append(f"arrowtail={arrowtail}")
+        if attr_str:
+            attrs.append(attr_str)
+        lines.append(f'    "{src}" -> "{dst}" [{", ".join(attrs)}];')
+
+    def _emit_edge_with_label_node(
+        src: str,
+        dst: str,
+        label: str,
+        *,
+        attr_str: str = "",
+        dir_val: str = "",
+        arrowhead: str = "",
+        arrowtail: str = "",
+    ) -> None:
+        nonlocal label_node_counter
+        node_id = f"perm_label_{label_node_counter}"
+        label_node_counter += 1
+        lines.append(
+            f'    "{node_id}" [shape=box, label="{label}", fontsize=9, margin="0.05,0.02", '
+            f'width=0, height=0, style="filled", fillcolor="#FFFFFF", color="#FFFFFF"];'
+        )
+        if dir_val == "both" and not arrowhead and not arrowtail:
+            _emit_edge(
+                src,
+                node_id,
+                attr_str=attr_str,
+                dir_val="both",
+                arrowhead="none",
+                arrowtail="normal",
+            )
+            _emit_edge(
+                node_id,
+                dst,
+                attr_str=attr_str,
+                dir_val="both",
+                arrowhead="normal",
+                arrowtail="none",
+            )
+            return
+
+        if dir_val == "none":
+            _emit_edge(
+                src,
+                node_id,
+                attr_str=attr_str,
+                dir_val="none",
+                arrowhead="none",
+                arrowtail="none",
+            )
+            _emit_edge(
+                node_id,
+                dst,
+                attr_str=attr_str,
+                dir_val="none",
+                arrowhead="none",
+                arrowtail="none",
+            )
+            return
+
+        _emit_edge(
+            src,
+            node_id,
+            attr_str=attr_str,
+            dir_val=dir_val,
+            arrowhead=arrowhead or "none",
+            arrowtail=arrowtail,
+        )
+        _emit_edge(
+            node_id,
+            dst,
+            attr_str=attr_str,
+            dir_val=dir_val,
+            arrowhead=arrowhead,
+            arrowtail=arrowtail,
+        )
+
+    def _emit_connection_edge(src, dst, *, full_label, perms_label, **kwargs):
+        if SHOW_EDGE_LABELS:
+            _emit_edge_with_label_node(src, dst, full_label, **kwargs)
+        elif SHOW_EDGE_PERMS:
+            _emit_edge_with_label_node(src, dst, perms_label, **kwargs)
+        else:
+            _emit_edge(src, dst, **kwargs)
+
+    # Subgraph clusters per interface
+    for iface in builder.interfaces:
+        lines.append(f"    subgraph cluster_iface{iface.index} {{")
+        if SHOW_NODE_LABELS:
+            lines.append(
+                f'        label="Interface {iface.index}: {iface.name} ({iface.ip}/{iface.subnet_bits})";'
+            )
+        lines.append("        style=rounded;")
+        lines.append('        color="#90CAF9";')
+        for pd, role in iface.wiring.all_pds():
+            if SHOW_NODE_LABELS:
+                lines.append(f'        "{pd.name}" [label="{role}\\n{pd.name}"];')
+            else:
+                lines.append(f'        "{pd.name}" [label=""];')
+        lines.append("    }")
+        lines.append("")
+
+    # Global PDs outside clusters
+    for pd, label in [
+        (getattr(builder, "webserver", None), "Webserver"),
+        (getattr(builder, "icmp_module", None), "ICMP Module"),
+    ]:
+        if pd:
+            if SHOW_NODE_LABELS:
+                lines.append(
+                    f'    "{pd.name}" [label="{label}\\n{pd.name}", fillcolor="#C8E6C9"];'
+                )
+            else:
+                lines.append(f'    "{pd.name}" [label="", fillcolor="#C8E6C9"];')
+    lines.append("")
+
+    # Connection edges
+    all_conns = _collect_all_connections(builder)
+    for name, spec in all_conns.items():
+        for edge in spec.topology_edges():
+            style_attrs = EDGE_STYLES.get(edge.category, {})
+            attr_str = ", ".join(f'{k}="{v}"' for k, v in style_attrs.items())
+
+            parts = [name]
+            if edge.channel_label:
+                parts.append(edge.channel_label)
+            parts.append(f"perm={edge.queue_perms}/{edge.queue_perms}")
+            if edge.extra_perms:
+                parts.append(f"dma={edge.extra_perms}")
+
+            dir_kw = {"dir_val": "both"} if edge.bidirectional else {}
+            _emit_connection_edge(
+                edge.src_name,
+                edge.dst_name,
+                full_label=" ".join(parts),
+                perms_label=QUEUE_PERMS_LABEL,
+                attr_str=attr_str,
+                **dir_kw,
+            )
+
+            if edge.extra_perms:
+                _emit_connection_edge(
+                    edge.src_name,
+                    edge.dst_name,
+                    full_label="DMA",
+                    perms_label=edge.extra_perms,
+                    attr_str='color="#BBDEFB"',
+                    dir_val="none",
+                    arrowhead="none",
+                    arrowtail="none",
+                )
+    lines.append("")
+
+    # sDDF Net edges (inferred)
+    all_net_edges = _collect_all_net_edges(builder)
+    for edge in all_net_edges:
+        style_attrs = EDGE_STYLES.get("sddf_net", {})
+        attr_str = ", ".join(f'{k}="{v}"' for k, v in style_attrs.items())
+        label = ""
+        if SHOW_EDGE_LABELS:
+            label = edge.label if edge.label else "sddf_net"
+            if edge.interface_index is not None:
+                label = f"{label} (iface {edge.interface_index})"
+        if edge.bidirectional:
+            _emit_edge_with_label_node(
+                edge.src_pd.name,
+                edge.dst_pd.name,
+                label,
+                dir_val="both",
+                attr_str=attr_str,
+            )
+        else:
+            _emit_edge_with_label_node(
+                edge.src_pd.name,
+                edge.dst_pd.name,
+                label,
+                attr_str=attr_str,
+            )
+    lines.append("")
+
+    # Region nodes (shared and private)
+    all_regions = _collect_all_regions(builder)
+    for name, spec in all_regions.items():
+        region_style = REGION_STYLES.get(spec.category, {})
+        fillcolor = region_style.get("fillcolor", "#FFFFFF")
+        if SHOW_NODE_LABELS:
+            lines.append(
+                f'    "{name}" [shape=note, label="{name}\\n{spec.size} bytes", fillcolor="{fillcolor}"];'
+            )
+        else:
+            lines.append(
+                f'    "{name}" [shape=note, label="", fillcolor="{fillcolor}"];'
+            )
+        for pd_name, perms in spec.topology_mappings():
+            _emit_connection_edge(
+                pd_name,
+                name,
+                full_label=perms,
+                perms_label=perms,
+                dir_val="none",
+                arrowhead="none",
+                arrowtail="none",
+            )
+    lines.append("")
+
+    # Legend
+    if SHOW_LEGEND:
+        lines.append("    subgraph cluster_legend {")
+        lines.append('        label="Legend";')
+        lines.append("        style=rounded;")
+        lines.append('        color="#E0E0E0";')
+        lines.append("        fontsize=10;")
+        lines.append("        node [style=filled];")
+        lines.append(
+            '        legend_pd [shape=box, fillcolor="#E3F2FD", label="PD (Protection Domain)"];'
+        )
+        lines.append(
+            '        legend_region [shape=note, fillcolor="#FFFFFF", label="Shared Region"];'
+        )
+        lines.append(
+            '        legend_cluster [shape=plaintext, label="Interface cluster = per-NIC PDs"];'
+        )
+
+        # Edge style samples
+        lines.append('        legend_data_src [shape=point, width=0.1, label=""];')
+        lines.append('        legend_data_dst [shape=point, width=0.1, label=""];')
+        lines.append(
+            '        legend_data_src -> legend_data_dst [label="Data", color="#2196F3", penwidth="2.0"];'
+        )
+
+        lines.append('        legend_dma_src [shape=point, width=0.1, label=""];')
+        lines.append('        legend_dma_dst [shape=point, width=0.1, label=""];')
+        lines.append(
+            '        legend_dma_src -> legend_dma_dst [label="DMA (data region)", color="#BBDEFB"];'
+        )
+
+        lines.append('        legend_buf_src [shape=point, width=0.1, label=""];')
+        lines.append('        legend_buf_dst [shape=point, width=0.1, label=""];')
+        lines.append(
+            '        legend_buf_src -> legend_buf_dst [label="Buffer Return", color="#9E9E9E"];'
+        )
+
+        lines.append('        legend_arp_src [shape=point, width=0.1, label=""];')
+        lines.append('        legend_arp_dst [shape=point, width=0.1, label=""];')
+        lines.append(
+            '        legend_arp_src -> legend_arp_dst [label="ARP (bidirectional)", dir=both, color="#FF9800", penwidth="1.5"];'
+        )
+
+        lines.append('        legend_filter_src [shape=point, width=0.1, label=""];')
+        lines.append('        legend_filter_dst [shape=point, width=0.1, label=""];')
+        lines.append(
+            '        legend_filter_src -> legend_filter_dst [label="Filter", color="#F44336", penwidth="1.5"];'
+        )
+
+        lines.append('        legend_icmp_src [shape=point, width=0.1, label=""];')
+        lines.append('        legend_icmp_dst [shape=point, width=0.1, label=""];')
+        lines.append(
+            '        legend_icmp_src -> legend_icmp_dst [label="ICMP", color="#9C27B0", penwidth="1.5"];'
+        )
+
+        lines.append('        legend_net_src [shape=point, width=0.1, label=""];')
+        lines.append('        legend_net_dst [shape=point, width=0.1, label=""];')
+        lines.append(
+            '        legend_net_src -> legend_net_dst [label="sDDF Net (inferred)", color="#607D8B"];'
+        )
+
+        lines.append("    }")
+
+    lines.append("}")
+    return "\n".join(lines)

--- a/include/lions/firewall/common.h
+++ b/include/lions/firewall/common.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <stdint.h>
 #include <sddf/util/util.h>
+#include <stdint.h>
 
 /**
  * Convert a 16 bit unsigned from host byte order to network byte order.
@@ -45,8 +45,8 @@ stored big-endian, so mask byte order must be swapped for subnet match. */
 
 /* Firewall ID number used by components to identify which interface they
 are connected to */
-#define FW_EXTERNAL_INTERFACE_ID 0
-#define FW_INTERNAL_INTERFACE_ID 1
+#define FW_EXTERNAL_INTERFACE_ID 1
+#define FW_INTERNAL_INTERFACE_ID 0
 
 /* Firewall component print formatting string to identify which interface
 component is printing */

--- a/include/lions/firewall/config.h
+++ b/include/lions/firewall/config.h
@@ -19,6 +19,7 @@
 
 #define FW_NUM_ARP_REQUESTER_CLIENTS 2
 #define FW_NUM_INTERFACES 2
+#define FW_MAX_INITIAL_FILTER_RULES 4
 
 #define FW_DEBUG_OUTPUT 1
 
@@ -125,19 +126,45 @@ typedef struct fw_icmp_module_config {
 typedef struct fw_webserver_filter_config {
     uint16_t protocol;
     uint8_t ch;
-    uint8_t default_action;
     region_resource_t rules;
     uint16_t rules_capacity;
 } fw_webserver_filter_config_t;
 
+typedef struct fw_rule {
+    /* action to be applied to traffic matching rule */
+    uint8_t action;
+    /* source IP */
+    uint32_t src_ip;
+    /* destination IP */
+    uint32_t dst_ip;
+    /* source port number */
+    uint16_t src_port;
+    /* destination port number */
+    uint16_t dst_port;
+    /* source subnet, 0 is any IP */
+    uint8_t src_subnet;
+    /* destination subnet, 0 is any IP */
+    uint8_t dst_subnet;
+    /* rule applies to any source port */
+    bool src_port_any;
+    /* rule applies to any destination port */
+    bool dst_port_any;
+    /* rule id assigned */
+    uint16_t rule_id;
+} fw_rule_t;
+
 typedef struct fw_filter_config {
     /* Interface traffic is received from */
     uint8_t interface;
+    fw_rule_t default_rule;
+    fw_rule_t initial_rules[FW_MAX_INITIAL_FILTER_RULES];
+    uint8_t num_initial_rules;
     uint16_t instances_capacity;
     fw_connection_resource_t router;
-    fw_webserver_filter_config_t webserver;
     region_resource_t internal_instances;
     region_resource_t external_instances;
+    region_resource_t rules;
+    uint16_t rules_capacity;
     region_resource_t rule_id_bitmap;
 } fw_filter_config_t;
 

--- a/include/lions/firewall/filter.h
+++ b/include/lions/firewall/filter.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
-#include <os/sddf.h>
-#include <stdint.h>
-#include <stdbool.h>
-#include <sddf/util/util.h>
-#include <sddf/network/util.h>
-#include <lions/firewall/common.h>
+#include "lions/firewall/config.h"
 #include <lions/firewall/array_functions.h>
+#include <lions/firewall/common.h>
+#include <os/sddf.h>
+#include <sddf/network/util.h>
+#include <sddf/util/util.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 /* The default action of a filter is always stored at index 0 of the rule table,
 and has a fixed rule ID of 0 */
@@ -28,8 +29,7 @@ typedef enum {
     FILTER_ERR_DUPLICATE,
     /* entry clashes with existing entry */
     FILTER_ERR_CLASH,
-    /* rule id does not point to a valid entry, or is the default action rule id
-    */
+    /* rule id does not point to a valid entry, or is the default action rule id */
     FILTER_ERR_INVALID_RULE_ID
 } fw_filter_err_t;
 
@@ -48,29 +48,6 @@ typedef enum {
 } fw_action_t;
 
 static const char *fw_filter_action_str[] = { "No rule", "Allow", "Drop", "Connect", "Established" };
-
-typedef struct fw_rule {
-    /* action to be applied to traffic matching rule */
-    uint8_t action;
-    /* source IP */
-    uint32_t src_ip;
-    /* destination IP */
-    uint32_t dst_ip;
-    /* source port number */
-    uint16_t src_port;
-    /* destination port number */
-    uint16_t dst_port;
-    /* source subnet, 0 is any IP */
-    uint8_t src_subnet;
-    /* destination subnet, 0 is any IP */
-    uint8_t dst_subnet;
-    /* rule applies to any source port */
-    bool src_port_any;
-    /* rule applies to any destination port */
-    bool dst_port_any;
-    /* rule id assigned */
-    uint16_t rule_id;
-} fw_rule_t;
 
 /**
  * Instances are created by filters if traffic matches with a connect rule.
@@ -212,46 +189,6 @@ static fw_filter_err_t rules_free_id(fw_filter_state_t *state, uint16_t rule_id)
 }
 
 /**
- * Initialise filter state.
- *
- * @param state address of filter state.
- * @param rules address of rules table.
- * @param rules_capacity capacity of rules table.
- * @param internal_instances address of internal instances.
- * @param external_instances address of external instances.
- * @param instances_capacity capacity of instance tables.
- * @param default_action default action of filter.
- */
-static inline void fw_filter_state_init(fw_filter_state_t *state, void *rules, void *rule_id_bitmap,
-                                        uint16_t rules_capacity, void *internal_instances, void *external_instances,
-                                        uint16_t instances_capacity, fw_action_t default_action)
-{
-    state->rule_table = (fw_rule_table_t *)rules;
-    state->rules_capacity = rules_capacity;
-    state->rule_id_bitmap = (fw_rule_id_bitmap_t *)rule_id_bitmap;
-    state->instances_capacity = instances_capacity;
-    state->internal_instances_table = (fw_instances_table_t *)internal_instances;
-    state->external_instances_table = (fw_instances_table_t *)external_instances;
-
-    /* Allocate the default action rule ID for the default action */
-    uint16_t default_block_idx = DEFAULT_ACTION_RULE_ID / RULE_ID_BITMAP_BLK_SIZE;
-    uint64_t default_mask = 1ULL << (DEFAULT_ACTION_RULE_ID % RULE_ID_BITMAP_BLK_SIZE);
-
-    /* No other rules should exist at this point */
-    assert((state->rule_id_bitmap->id_bitmap[default_block_idx] & default_mask) == 0);
-    assert(state->rule_table->size == 0);
-
-    state->rule_id_bitmap->id_bitmap[default_block_idx] |= default_mask;
-    state->rule_id_bitmap->last_allocated_rule_id = DEFAULT_ACTION_RULE_ID;
-
-    state->rule_table->rules[DEFAULT_ACTION_IDX].src_port_any = true;
-    state->rule_table->rules[DEFAULT_ACTION_IDX].dst_port_any = true;
-    state->rule_table->rules[DEFAULT_ACTION_IDX].action = default_action;
-    state->rule_table->rules[DEFAULT_ACTION_IDX].rule_id = DEFAULT_ACTION_RULE_ID;
-    state->rule_table->size++;
-}
-
-/**
  * Add a filtering rule.
  *
  * @param state address of filter state.
@@ -336,6 +273,53 @@ static inline fw_filter_err_t fw_filter_add_rule(fw_filter_state_t *state, uint3
     empty_slot->rule_id = *rule_id;
     state->rule_table->size++;
     return FILTER_ERR_OKAY;
+}
+
+/**
+ * Initialise filter state.
+ *
+ * @param state address of filter state.
+ * @param rules address of rules table.
+ * @param rules_capacity capacity of rules table.
+ * @param internal_instances address of internal instances.
+ * @param external_instances address of external instances.
+ * @param instances_capacity capacity of instance tables.
+ * @param default_rule default rule of filter.
+ * @param initial_rules array of initial rules to insert.
+ * @param num_rules number of initial rules.
+ */
+static inline void fw_filter_state_init(fw_filter_state_t *state, void *rules, void *rule_id_bitmap,
+                                        uint16_t rules_capacity, void *internal_instances, void *external_instances,
+                                        uint16_t instances_capacity, fw_rule_t default_rule, fw_rule_t *initial_rules,
+                                        uint8_t num_rules)
+{
+    state->rule_table = (fw_rule_table_t *)rules;
+    state->rules_capacity = rules_capacity;
+    state->rule_id_bitmap = (fw_rule_id_bitmap_t *)rule_id_bitmap;
+    state->instances_capacity = instances_capacity;
+    state->internal_instances_table = (fw_instances_table_t *)internal_instances;
+    state->external_instances_table = (fw_instances_table_t *)external_instances;
+
+    /* Allocate the default action rule ID for the default action */
+    uint16_t default_block_idx = DEFAULT_ACTION_RULE_ID / RULE_ID_BITMAP_BLK_SIZE;
+    uint64_t default_mask = 1ULL << (DEFAULT_ACTION_RULE_ID % RULE_ID_BITMAP_BLK_SIZE);
+
+    /* No other rules should exist at this point */
+    assert((state->rule_id_bitmap->id_bitmap[default_block_idx] & default_mask) == 0);
+    assert(state->rule_table->size == 0);
+
+    state->rule_id_bitmap->id_bitmap[default_block_idx] |= default_mask;
+    state->rule_id_bitmap->last_allocated_rule_id = DEFAULT_ACTION_RULE_ID;
+
+    state->rule_table->rules[DEFAULT_ACTION_IDX] = default_rule;
+    state->rule_table->size++;
+
+    for (uint8_t r = 0; r < num_rules; r++) {
+        fw_filter_add_rule(state, initial_rules[r].src_ip, initial_rules[r].src_port, initial_rules[r].dst_ip,
+                           initial_rules[r].dst_port, initial_rules[r].src_subnet, initial_rules[r].dst_subnet,
+                           initial_rules[r].src_port_any, initial_rules[r].dst_port_any, initial_rules[r].action,
+                           &initial_rules[r].rule_id);
+    }
 }
 
 /**


### PR DESCRIPTION
This commit primarily refactors the meta program. The goal was to represent the various connections and components in python data classes to improve the readability of the meta program.

By representing these connections and components in data classes this commit supports generating a dot file which can be used to view schematics/topology of the design defined in the meta program.

In addition this commit changes the internal and external labelling to align with the underlying hardware. The internal and external naming is now just a label with the meta program now being better able to support more than two interfaces.

In addition this commit added the ability to configure initial rules for the filter components in the meta program. This was done here in preparation for the router unification which uses these changes to enforce the desired webserver filtering namely (port 80, tcp traffic and only accessible via internal network).