### PR TITLE
Pass MAKEFLAGS down to submake

### DIFF
--- a/examples/kitty/Makefile
+++ b/examples/kitty/Makefile
@@ -29,7 +29,7 @@ REPORT_FILE := $(BUILD_DIR)/report.txt
 all: ${IMAGE_FILE}
 
 qemu ${IMAGE_FILE} ${REPORT_FILE} clean clobber: ${BUILD_DIR}/Makefile FORCE
-	${MAKE} -C ${BUILD_DIR} MICROKIT_SDK=${MICROKIT_SDK} $(notdir $@)
+	${MAKE} -C ${BUILD_DIR} -${MAKEFLAGS} $(notdir $@)
 
 ${BUILD_DIR}/Makefile: kitty.mk
 	mkdir -p ${BUILD_DIR}

--- a/examples/kitty/kitty.mk
+++ b/examples/kitty/kitty.mk
@@ -152,7 +152,12 @@ ${IMAGES}: $(LIONS_LIBC)/lib/libc.a libsddf_util_debug.a
 %.o: %.c ${SDDF}/include
 	${CC} ${CFLAGS} -c -o $@ $<
 
-$(SYSTEM_FILE): $(METAPROGRAM) $(IMAGES) $(DTB)
+NFS_ARGS := $(shell echo ${NFS_SERVER} ${NFS_DIRECTORY} | shasum | sed 's/  *-.*//')
+.NFS_ARGS-${NFS_ARGS}:
+	rm -f .NFS_ARGS*
+	> $@
+
+$(SYSTEM_FILE): $(METAPROGRAM) $(IMAGES) $(DTB) .NFS_ARGS-${NFS_ARGS}
 	PYTHONPATH=${SDDF}/tools/meta:$$PYTHONPATH $(PYTHON) $(METAPROGRAM) \
 		--sddf $(SDDF) --board $(MICROKIT_BOARD) \
 		--dtb $(DTB) --output . --sdf $(SYSTEM_FILE) \


### PR DESCRIPTION
also make system file depend on Makefile variables, so it gets rebuilt if they change.