### PR TITLE
Firewall: Fix python configuration to align qemu and hardware and minor type hint issues.

### DIFF
--- a/examples/firewall/pyfw/component_fw_interface.py
+++ b/examples/firewall/pyfw/component_fw_interface.py
@@ -78,7 +78,7 @@ class FirewallInterface(NetworkInterface):
         return self._arp_responder
 
     @arp_responder.setter
-    def arp_responder(self, arp_responder: ArpRequester):
+    def arp_responder(self, arp_responder: ArpResponder):
         assert arp_responder is not None
         self._arp_responder = arp_responder
 

--- a/examples/firewall/pyfw/component_net_virt.py
+++ b/examples/firewall/pyfw/component_net_virt.py
@@ -58,7 +58,7 @@ class NetVirtRx(Component, FwNetVirtRxConfig):
         assert self.active_client_ethtypes is not None
         assert self.active_client_subtypes is not None
         for cli in range(len(self.active_client_ethtypes)):
-            assert self.active_client_ethtypes[cli] != ethtype or self.active_client_subtypes != subtype
+            assert self.active_client_ethtypes[cli] != ethtype or self.active_client_subtypes[cli] != subtype
         # Set what traffic gets forwarded to the client
         self.active_client_ethtypes.append(ethtype)
         self.active_client_subtypes.append(subtype)

--- a/examples/firewall/pyfw/constants.py
+++ b/examples/firewall/pyfw/constants.py
@@ -22,8 +22,8 @@ BOARDS = [
         paddr_top=0x6_0000_000,
         serial="pl011@9000000",
         timer="timer",
-        ethernet0="virtio_mmio@a003c00",
-        ethernet1="virtio_mmio@a003e00",
+        ethernet0="virtio_mmio@a003e00",
+        ethernet1="virtio_mmio@a003c00",
     ),
     Board(
         name="imx8mp_iotgate",
@@ -70,7 +70,7 @@ interfaces = [
     NetworkInterface(
         index=0,
         name="external",
-        board_ethernet="ethernet1",
+        board_ethernet="ethernet0",
         mac=(0x00, 0x01, 0xC0, 0x39, 0xD5, 0x18),
         ip="172.16.2.1",
         subnet_bits=16,
@@ -78,7 +78,7 @@ interfaces = [
     NetworkInterface(
         index=1,
         name="internal",
-        board_ethernet="ethernet0",
+        board_ethernet="ethernet1",
         mac=(0x00, 0x01, 0xC0, 0x39, 0xD5, 0x10),
         ip="192.168.1.1",
         subnet_bits=24,
@@ -107,7 +107,7 @@ supported_filter_actions = {
 
 def construct_rule(action: int, src_ip: int, src_subnet: int, src_port: int, src_port_any: bool,
                    dst_ip: int, dst_subnet: int, dst_port: int, dst_port_any: bool) -> FwRule:
-    assert action in (FILTER_ACTION_ALLOW, FILTER_ACTION_DROP, FILTER_ACTION_CONNECT)
+    assert action in (FILTER_ACTION_ALLOW, FILTER_ACTION_DROP, FILTER_ACTION_CONNECT, FILTER_ACTION_REJECT)
     return FwRule(
         action=action,
         src_ip=src_ip,


### PR DESCRIPTION
In the python configuration, corrected incorrect typing, included all forms of filter rules in the assert and upated the qemu and hardware assignment of boards to be consistent.