### PR TITLE
Firewall: Handle IPV4 Header Options

### DIFF
--- a/examples/firewall/filters/icmp_filter.c
+++ b/examples/firewall/filters/icmp_filter.c
@@ -116,7 +116,7 @@ static void filter(void)
                 break;
             }
             case FILTER_ACT_REJECT: {
-                icmp_hdr_t *icmp_hdr = (icmp_hdr_t *)(pkt_vaddr + ICMP_HDR_OFFSET);
+                icmp_hdr_t *icmp_hdr = (icmp_hdr_t *)(pkt_vaddr + transport_layer_offset(ip_hdr));
                 uint8_t icmp_type = icmp_hdr->type;
                 /* An ICMP error message shouldn't be sent upon reception of another ICMP error message */
                 if (!icmp_is_error_message(icmp_type)) {

--- a/examples/firewall/icmp/icmp_module.c
+++ b/examples/firewall/icmp/icmp_module.c
@@ -82,7 +82,7 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
     icmp_hdr->type = req->type;
     icmp_hdr->code = req->code;
 
-    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, ntohs(req->ip_hdr.tot_len) - IPV4_HDR_LEN_MIN);
+    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, ntohs(req->ip_hdr.tot_len) - ipv4_header_length(&req->ip_hdr));
 
     /* Handle each ICMP type separately */
     switch (req->type) {
@@ -91,7 +91,7 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         ip_hdr->dst_ip = req->ip_hdr.src_ip;
 
         /* Total length of ICMP destination unreachable IP packet */
-        uint16_t icmp_total_len = (uint16_t)(ICMP_COMMON_HDR_LEN + ICMP_ECHO_NO_DATA_LEN + req->echo.payload_len);
+        uint16_t icmp_total_len = (uint16_t)(ICMP_COMMON_HDR_LEN + offsetof(icmp_echo_t, data) + req->echo.payload_len);
         ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + icmp_total_len);
 
         /* Construct ICMP echo reply: 4 bytes (id + seq) */

--- a/examples/firewall/routing/routing.c
+++ b/examples/firewall/routing/routing.c
@@ -216,10 +216,10 @@ static void route(void)
                     }
 
                     /* Check for ICMP pings */
-                    icmp_hdr_t *icmp_hdr = (icmp_hdr_t *)(pkt_vaddr + ICMP_HDR_OFFSET);
+                    icmp_hdr_t *icmp_hdr = (icmp_hdr_t *)(pkt_vaddr + transport_layer_offset(ip_hdr));
                     if (ip_hdr->protocol == IPV4_PROTO_ICMP && icmp_hdr->type == ICMP_ECHO_REQ
                         && ping_response_enabled[interface]) {
-                            notify_icmp |= icmp_enqueue_echo_reply(&icmp_queue, pkt_vaddr, interface);
+                        notify_icmp |= icmp_enqueue_echo_reply(&icmp_queue, pkt_vaddr, interface);
                     }
 
                     err = fw_enqueue(&rx_free[interface], &buffer);

--- a/include/lions/firewall/icmp.h
+++ b/include/lions/firewall/icmp.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 #include <lions/firewall/ip.h>
 #include <lions/firewall/queue.h>
@@ -119,7 +120,6 @@ typedef struct __attribute__((__packed__)) icmp_echo {
 
 /* Total length of ICMP echo request/reply packet with maximum payload */
 #define ICMP_ECHO_LEN (ICMP_COMMON_HDR_LEN + sizeof(icmp_echo_t))
-#define ICMP_ECHO_NO_DATA_LEN ((sizeof(icmp_echo_t) - FW_ICMP_ECHO_PAYLOAD_LEN))
 
 /* ----------------- 11 - Time Exceeded ---------------------------*/
 typedef struct __attribute__((__packed__)) icmp_time_exceeded {
@@ -233,8 +233,9 @@ static inline bool icmp_enqueue_error(fw_queue_t *icmp_queue, uint8_t type, uint
     memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
 
     /* Copy first bytes of data if applicable */
-    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(ip_hdr->tot_len) - IPV4_HDR_LEN_MIN);
-    memcpy(req.dest.data, (void *)(pkt_vaddr + IPV4_HDR_OFFSET + IPV4_HDR_LEN_MIN), to_copy);
+    uint8_t ip_hdr_len = ipv4_header_length(ip_hdr);
+    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(ip_hdr->tot_len) - ip_hdr_len);
+    memcpy(req.dest.data, (void *)(pkt_vaddr + transport_layer_offset(ip_hdr)), to_copy);
 
     return fw_enqueue(icmp_queue, &req) == 0;
 }
@@ -253,13 +254,13 @@ static inline bool icmp_enqueue_echo_reply(fw_queue_t *icmp_queue, uintptr_t pkt
     ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
 
     /* Extract echo id and sequence from the ICMP echo header */
-    icmp_echo_t *echo_hdr = (icmp_echo_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET);
+    icmp_echo_t *echo_hdr = (icmp_echo_t *)(pkt_vaddr + transport_layer_offset(ip_hdr) + ICMP_COMMON_HDR_LEN);
     uint16_t echo_id = ntohs(echo_hdr->id);
     uint16_t echo_seq = ntohs(echo_hdr->seq);
 
     /* Calculate payload length */
     uint16_t icmp_total_len = htons(ip_hdr->tot_len) - ipv4_header_length(ip_hdr);
-    uint16_t payload_len = icmp_total_len - ICMP_COMMON_HDR_LEN - ICMP_ECHO_NO_DATA_LEN;
+    uint16_t payload_len = icmp_total_len - ICMP_COMMON_HDR_LEN - offsetof(icmp_echo_t, data);
     if (payload_len > FW_ICMP_ECHO_PAYLOAD_LEN) {
         payload_len = FW_ICMP_ECHO_PAYLOAD_LEN;
     }
@@ -279,7 +280,8 @@ static inline bool icmp_enqueue_echo_reply(fw_queue_t *icmp_queue, uintptr_t pkt
     memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
 
     /* Copy payload */
-    uint8_t *payload_data = (uint8_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET + ICMP_ECHO_NO_DATA_LEN);
+    uint8_t *payload_data = (uint8_t *)(pkt_vaddr + transport_layer_offset(ip_hdr) + ICMP_COMMON_HDR_LEN
+                                        + offsetof(icmp_echo_t, data));
     memcpy(req.echo.data, payload_data, payload_len);
 
     return fw_enqueue(icmp_queue, &req) == 0;
@@ -310,8 +312,8 @@ static inline int icmp_enqueue_redirect(fw_queue_t *icmp_queue, uint8_t code, ui
 
     /* Set gateway IP and copy first bytes of data */
     req.redirect.gateway_ip = gateway_ip;
-    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(ip_hdr->tot_len) - IPV4_HDR_LEN_MIN);
-    memcpy(req.redirect.data, (void *)(pkt_vaddr + IPV4_HDR_OFFSET + IPV4_HDR_LEN_MIN), to_copy);
+    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(ip_hdr->tot_len) - ipv4_header_length(ip_hdr));
+    memcpy(req.redirect.data, (void *)(pkt_vaddr + transport_layer_offset(ip_hdr)), to_copy);
 
     return fw_enqueue(icmp_queue, &req);
 }


### PR DESCRIPTION
Modified code to handle the fact that the IPV4 header length is not always equal to the minimum when optional fields are included.

ICMP_FILTER.C: use transport_layer_offset rather than assuming hdr offsets.
ICMP_MODULE.C: use ipv4_header_length rather than assuming minimum ipv4 hdr len & use offset(data) rather than double counding the payload.
ROUTING.C: use transport_layer_offset rather than assuming minimum hdrs.
ICMP.H: changed ICMP_ECHO_LEN constant to not double count payload len. Updated offset calculations to use transport_layer_offset rather than assuming minimum hdr length. Use offset(icmp_echo_t, data) to retrieve offset to the data part of the icmp_echo_t struct.