### PR TITLE
micropython: fix RISC-V builds

### DIFF
--- a/components/micropython/Makefile
+++ b/components/micropython/Makefile
@@ -17,8 +17,8 @@ FROZEN_MANIFEST ?= $(MICROPYTHON_SRC)/extmod/asyncio/manifest.py
 include $(MICROPYTHON_SRC)/py/mkenv.mk
 
 # Override mkenv.mk settings.
-CC = $(USE_CC)
-LD = $(USE_LD)
+CC := $(USE_CC)
+LD := $(USE_LD)
 SIZE := $(USE_SIZE)
 
 # Include py core make definitions.
@@ -45,8 +45,7 @@ CFLAGS += \
 	-Wno-shift-op-parentheses \
 	-DLWIP_TCP_KEEPALIVE=1 \
 	-ffreestanding \
-	-mtune=$(CPU) \
-	-target $(TARGET)
+	$(CFLAGS_ARCH)
 
 LDFLAGS += -L$(BOARD_DIR)/lib -L$(MICROPYTHON_LIBC)/lib
 LIBS += -lmicrokit -Tmicrokit.ld -lc $(BUILD)/libsddf_util_debug.a $(BUILD)/lib_sddf_lwip_mp.a $(BUILD)/libmicrokitco_mp.a

--- a/components/micropython/micropython.mk
+++ b/components/micropython/micropython.mk
@@ -48,8 +48,7 @@ micropython.elf: FORCE mpy-cross \
 		MICROKIT_SDK=$(MICROKIT_SDK) \
 		MICROKIT_BOARD=$(MICROKIT_BOARD) \
 		MICROKIT_CONFIG=$(MICROKIT_CONFIG) \
-		CPU=$(CPU) \
-		TARGET=$(TARGET) \
+		CFLAGS_ARCH='$(CFLAGS_ARCH)' \
 		USE_CC=$(CC) \
 		USE_LD=$(LD) \
 		USE_SIZE=llvm-size \

--- a/components/micropython/mpconfigport.h
+++ b/components/micropython/mpconfigport.h
@@ -90,25 +90,7 @@ typedef long mp_off_t;
 // We need to provide a declaration/definition of alloca().
 #include <alloca.h>
 
-// Define the port's name and hardware.
-#if defined(CONFIG_PLAT_ODROIDC4)
-#define MICROPY_HW_BOARD_NAME "Odroid-C4"
-#define MICROPY_HW_MCU_NAME   "Cortex A55"
-#elif defined(CONFIG_PLAT_IMX8MM_EVK)
-#define MICROPY_HW_BOARD_NAME "i.MX 8M Mini"
-#define MICROPY_HW_MCU_NAME   "Cortex A53"
-#elif defined(CONFIG_PLAT_IMX8MP_EVK)
-#define MICROPY_HW_BOARD_NAME "i.MX 8MP"
-#define MICROPY_HW_MCU_NAME   "Cortex A53"
-#elif defined(CONFIG_PLAT_MAAXBOARD)
-#define MICROPY_HW_BOARD_NAME "MaaXBoard"
-#define MICROPY_HW_MCU_NAME   "Cortex A53"
-#elif defined(CONFIG_PLAT_QEMU_ARM_VIRT)
-#define MICROPY_HW_BOARD_NAME "QEMU virt AArch64"
-#define MICROPY_HW_MCU_NAME   "Cortex A53"
-#else
-#error "Unknown platform given for MicroPython config"
-#endif
+#define MICROPY_BANNER_MACHINE "LionsOS"
 
 #define MP_STATE_PORT MP_STATE_VM
 


### PR DESCRIPTION
* Pass through `CFLAGS_ARCH`
* Don't hardcode board names because this is annoying for adding board support