### PR TITLE
Perform further libc initialisation

### DIFF
--- a/lib/libc/posix/posix.c
+++ b/lib/libc/posix/posix.c
@@ -119,6 +119,11 @@ static long sys_getgid(va_list ap) {
     return 501;
 }
 
+static long sys_set_tid_address(va_list ap) {
+    (void)ap;
+    return 0;
+}
+
 // FIXME: this is deliberately insecure for now
 static long sys_getrandom(va_list ap) {
     void *buf = va_arg(ap, void *);
@@ -205,6 +210,7 @@ void libc_init(libc_socket_config_t *socket_config) {
     libc_define_syscall(__NR_getuid, sys_getuid);
     libc_define_syscall(__NR_getgid, sys_getgid);
     libc_define_syscall(__NR_getrandom, sys_getrandom);
+    libc_define_syscall(__NR_set_tid_address, sys_set_tid_address);
 
     /*
      * Let libc initialise itself

--- a/lib/libc/posix/posix.c
+++ b/lib/libc/posix/posix.c
@@ -36,9 +36,19 @@
 //TODO: fix to use header; have issue with providing correct libmicrokitco_opts.h
 void microkit_cothread_wait_on_channel(const microkit_channel wake_on);
 
+//TODO: fix to use header in "dep/musllibc/src/internal/libc.h"
+void __init_libc(char**, char*);
+void __libc_start_init(void);
+
 extern size_t __sysinfo;
 extern timer_client_config_t timer_config;
 static muslcsys_syscall_t syscall_table[MUSLC_NUM_SYSCALLS] = { 0 };
+
+// __init_libc expects an environment to be passed in
+static char* envp[] = {
+    NULL, /* No environment variables */
+    NULL /* No auxillary vector */
+};
 
 static long sys_clock_gettime(va_list ap) {
     clockid_t clk_id = va_arg(ap, clockid_t);
@@ -195,4 +205,11 @@ void libc_init(libc_socket_config_t *socket_config) {
     libc_define_syscall(__NR_getuid, sys_getuid);
     libc_define_syscall(__NR_getgid, sys_getgid);
     libc_define_syscall(__NR_getrandom, sys_getrandom);
+
+    /*
+     * Let libc initialise itself
+     * This is effectively what __libc_start_main does *apart* from exit(main(argc, argv))
+     */
+    __init_libc(envp, NULL);
+    __libc_start_init();
 }

--- a/lib/libc/posix/posix.c
+++ b/lib/libc/posix/posix.c
@@ -106,7 +106,9 @@ static long sys_nanosleep(va_list ap) {
 
 static long sys_getpid(va_list ap) {
     (void)ap;
-    return 0;
+
+    // PID == TID for a single-threaded process
+    return 1;
 }
 
 static long sys_getuid(va_list ap) {
@@ -121,7 +123,11 @@ static long sys_getgid(va_list ap) {
 
 static long sys_set_tid_address(va_list ap) {
     (void)ap;
-    return 0;
+
+    // This syscall eventually returns the caller's thread ID
+    // Since we're in a single-threaded environment, PID == TID *but* 0 doesn't work
+    // since the pthreads library assumes 0 is an invalid TID
+    return 1;
 }
 
 // FIXME: this is deliberately insecure for now


### PR DESCRIPTION
`musllibc` expects programs to start executing via `_start` and so its start routine contains calls to internal initialisation routines which among other things, allocates memory for thread-local storage. This PR adds these internal routines to the tail of our custom `init_libc` so that we also initialise `musllibc` as expected.