### PR TITLE
changed faulty line in posix_test, ran all examples except vmm & kitty.

### DIFF
--- a/examples/posix_test/posix_test.mk
+++ b/examples/posix_test/posix_test.mk
@@ -169,7 +169,7 @@ qemu: ${IMAGE_FILE} qemu_disk
 		-nographic \
 		-global virtio-mmio.force-legacy=false \
 		-d guest_errors \
-		-drive file=qemu_disk,if=none,format=raw,id=hd,bus=virtio-mmio-bus.1 \
+		-drive file=qemu_disk,if=none,format=raw,id=hd \
 		-device virtio-blk-device,drive=hd,bus=virtio-mmio-bus.1 \
 		-device virtio-net-device,netdev=netdev0,bus=virtio-mmio-bus.0 \
 		-netdev user,id=netdev0,hostfwd=tcp::5560-10.0.2.15:5560,hostfwd=tcp::5561-10.0.2.15:5561


### PR DESCRIPTION
Fixes #319.

Two line change, added an include to allow compilation & fixed faulty line in makefile.
Ran all examples except vmm & kitty.