### PR TITLE
libc: clients provide heap memory

### DIFF
--- a/components/fs/nfs/nfs.c
+++ b/components/fs/nfs/nfs.c
@@ -45,6 +45,8 @@ struct fs_queue *fs_command_queue;
 struct fs_queue *fs_completion_queue;
 char *fs_share;
 
+static char libc_heap[0x100000];
+
 struct nfs_context *nfs;
 
 net_queue_handle_t net_rx_handle;
@@ -119,7 +121,7 @@ void init(void) {
     serial_queue_init(&serial_tx_queue_handle, serial_config.tx.queue.vaddr, serial_config.tx.data.size,
                       serial_config.tx.data.vaddr);
 
-    libc_init(&socket_config);
+    libc_init(&socket_config, libc_heap, sizeof(libc_heap));
     continuation_pool_init();
 
     net_queue_init(&net_rx_handle, net_config.rx.free_queue.vaddr, net_config.rx.active_queue.vaddr,

--- a/components/micropython/micropython.c
+++ b/components/micropython/micropython.c
@@ -63,6 +63,8 @@ fs_queue_t *fs_command_queue;
 fs_queue_t *fs_completion_queue;
 char *fs_share;
 
+static char libc_heap[0x100000];
+
 serial_queue_handle_t serial_rx_queue_handle;
 serial_queue_handle_t serial_tx_queue_handle;
 
@@ -236,7 +238,7 @@ void init(void) {
     stack_ptrs_arg_array_t costacks = { (uintptr_t) mp_stack };
     microkit_cothread_init(&co_controller_mem, MICROPY_STACK_SIZE, costacks);
 
-    libc_init(&socket_config);
+    libc_init(&socket_config, libc_heap, sizeof(libc_heap));
 
     if (microkit_cothread_spawn(t_mp_entrypoint, NULL) == LIBMICROKITCO_NULL_HANDLE) {
         printf("MP|ERROR: Cannot initialise Micropython cothread\n");

--- a/components/wamr/wamr.c
+++ b/components/wamr/wamr.c
@@ -57,6 +57,8 @@ fs_queue_t *fs_command_queue;
 fs_queue_t *fs_completion_queue;
 char *fs_share;
 
+static char libc_heap[0x100000];
+
 serial_queue_handle_t serial_rx_queue_handle;
 serial_queue_handle_t serial_tx_queue_handle;
 
@@ -74,7 +76,7 @@ static void netif_status_callback(char *ip_addr) {
 }
 
 static void wamr_main() {
-    libc_init(&socket_config);
+    libc_init(&socket_config, libc_heap, sizeof(libc_heap));
 
     printf("WAMR | Starting WAMR...\n");
 

--- a/examples/posix_test/test_client.c
+++ b/examples/posix_test/test_client.c
@@ -69,6 +69,8 @@ bool serial_rx_enabled;
 
 #define LIBC_COTHREAD_STACK_SIZE 0x10000
 static char libc_cothread_stack[LIBC_COTHREAD_STACK_SIZE];
+
+static char libc_heap[0x100000];
 static co_control_t co_controller_mem;
 
 static bool dhcp_ready = false;
@@ -739,7 +741,7 @@ void run_tests(void) {
 }
 
 void cont(void) {
-    libc_init(&socket_config);
+    libc_init(&socket_config, libc_heap, sizeof(libc_heap));
 
     if (net_enabled) {
         net_queue_init(&net_rx_handle, net_config.rx.free_queue.vaddr, net_config.rx.active_queue.vaddr,

--- a/examples/posix_test/test_core.c
+++ b/examples/posix_test/test_core.c
@@ -39,6 +39,8 @@ bool serial_rx_enabled;
 
 #define LIBC_COTHREAD_STACK_SIZE 0x10000
 static char libc_cothread_stack[LIBC_COTHREAD_STACK_SIZE];
+
+static char libc_heap[0x100000];
 static co_control_t co_controller_mem;
 
 #define TEST_COMPONENT "core"
@@ -219,7 +221,7 @@ void run_tests(void) {
 }
 
 void cont(void) {
-    libc_init(NULL);
+    libc_init(NULL, libc_heap, sizeof(libc_heap));
     run_tests();
 }
 

--- a/examples/posix_test/test_file.c
+++ b/examples/posix_test/test_file.c
@@ -44,6 +44,8 @@ bool serial_rx_enabled;
 
 #define LIBC_COTHREAD_STACK_SIZE 0x10000
 static char libc_cothread_stack[LIBC_COTHREAD_STACK_SIZE];
+
+static char libc_heap[0x100000];
 static co_control_t co_controller_mem;
 
 static void blocking_wait(microkit_channel ch) { microkit_cothread_wait_on_channel(ch); }
@@ -732,7 +734,7 @@ void run_tests(void) {
 }
 
 void cont(void) {
-    libc_init(NULL);
+    libc_init(NULL, libc_heap, sizeof(libc_heap));
 
     if (fs_enabled) {
         fs_cmpl_t completion;

--- a/examples/posix_test/test_server.c
+++ b/examples/posix_test/test_server.c
@@ -53,6 +53,8 @@ bool serial_rx_enabled;
 
 #define LIBC_COTHREAD_STACK_SIZE 0x10000
 static char libc_cothread_stack[LIBC_COTHREAD_STACK_SIZE];
+
+static char libc_heap[0x100000];
 static co_control_t co_controller_mem;
 
 static bool dhcp_ready = false;
@@ -355,7 +357,7 @@ void run_tests(void) {
 }
 
 void cont(void) {
-    libc_init(&socket_config);
+    libc_init(&socket_config, libc_heap, sizeof(libc_heap));
 
     if (net_enabled) {
         net_queue_init(&net_rx_handle, net_config.rx.free_queue.vaddr, net_config.rx.active_queue.vaddr,

--- a/include/lions/posix/posix.h
+++ b/include/lions/posix/posix.h
@@ -38,6 +38,8 @@ typedef struct {
     int (*tcp_socket_getpeername)(int index, uint32_t *addr, uint16_t *port);
 } libc_socket_config_t;
 
-void libc_init(libc_socket_config_t *socket_config);
+/* heap and heap_size: memory region to use for malloc/brk/mmap.
+   Pass NULL/0 if the component does not need heap allocation. */
+void libc_init(libc_socket_config_t *socket_config, void *heap, size_t heap_size);
 void libc_define_syscall(int syscall_num, muslcsys_syscall_t syscall_func);
 int socket_index_of_fd(int fd);

--- a/lib/libc/posix/mem.c
+++ b/lib/libc/posix/mem.c
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <assert.h>
 #include <errno.h>
-#include <stdalign.h>
 #include <stdarg.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <sys/mman.h>
 #include <sys/types.h>
@@ -13,18 +14,9 @@
 
 #define PAGE_SIZE 0x1000
 
-/*
- * Statically allocated morecore area.
- *
- * This is rather terrible, but is the simplest option without a
- * huge amount of infrastructure.
- */
-#define MORECORE_AREA_BYTE_SIZE 0x100000
-static alignas(8) char morecore_area[MORECORE_AREA_BYTE_SIZE];
-
-/* Pointer to free space in the morecore area. */
-static uintptr_t morecore_base = (uintptr_t)&morecore_area;
-static uintptr_t morecore_top = (uintptr_t)&morecore_area[MORECORE_AREA_BYTE_SIZE];
+static char *morecore_area;
+static uintptr_t morecore_base;
+static uintptr_t morecore_top;
 
 /* Actual morecore implementation
    On Linux, the brk syscall returns the current break on failure. We mimic
@@ -33,7 +25,7 @@ static uintptr_t morecore_top = (uintptr_t)&morecore_area[MORECORE_AREA_BYTE_SIZ
 static long sys_brk(va_list ap) {
     uintptr_t newbrk = va_arg(ap, uintptr_t);
 
-    if (newbrk <= morecore_top && newbrk >= (uintptr_t)&morecore_area[0]) {
+    if (newbrk <= morecore_top && newbrk >= (uintptr_t)morecore_area) {
         return morecore_base = newbrk;
     }
 
@@ -84,7 +76,13 @@ static long sys_mprotect(va_list ap) {
     return 0;
 }
 
-void libc_init_mem() {
+void libc_init_mem(void *area, size_t size) {
+    assert(area != NULL && size != 0);
+
+    morecore_area = area;
+    morecore_base = (uintptr_t)area;
+    morecore_top = morecore_base + size;
+
     libc_define_syscall(__NR_brk, sys_brk);
     libc_define_syscall(__NR_mmap, sys_mmap);
     libc_define_syscall(__NR_munmap, sys_munmap);

--- a/lib/libc/posix/posix.c
+++ b/lib/libc/posix/posix.c
@@ -194,15 +194,18 @@ void libc_define_syscall(int syscall_num, muslcsys_syscall_t syscall_func) {
     syscall_table[syscall_num] = syscall_func;
 }
 
-void libc_init_mem();
+void libc_init_mem(void *, size_t);
 void libc_init_io();
 void libc_init_file();
 void libc_init_sock(libc_socket_config_t *);
 
-void libc_init(libc_socket_config_t *socket_config) {
-    /* Syscall table init */
+void libc_init(libc_socket_config_t *socket_config, void *heap, size_t heap_size) {
     __sysinfo = (size_t)sel4_vsyscall;
-    libc_init_mem();
+
+    if (heap != NULL && heap_size > 0) {
+        libc_init_mem(heap, heap_size);
+    }
+
     libc_init_io();
     libc_init_file();
 


### PR DESCRIPTION
Instead of a fixed static array in the library itself, the `libc_init` API has now changed to allow library users to provide their own region for malloc etc.