### PR TITLE
Added preliminary maintainers.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,38 @@
+<!--
+    Copyright 2026, UNSW
+
+    SPDX-License-Identifier: BSD-2-Clause
+-->
+# MAINTAINERS.md
+
+This file lists ownership of components of the LionsOS. These people are your
+first port of call for code review or technical advice on their respective components.
+
+## Default reviewer
+
+For new components or changes to miscellaneous parts of LionsOS that do not have
+an obvious reviewer, contact one of the default reviewers.
+
+The default reviewers of the LionsOS are currently
+* Courtney (`@Courtney3141`)
+
+## Components list
+
+* `ci/` - Julia (`@midnightveil`)
+* `components/`
+    * `fs/` - Simon (`@dumsum`)
+    * `micropython/` - Courtney (`@Courtney3141`)
+    * `wamr/` - Simon (`@dumsum`)
+* `examples/`
+    * `fileio` - UNASSIGNED (`@`)
+    * `firewall` - Courtney (`@Courtney3141`)
+    * `kitty` - Courtney (`@Courtney3141`)
+    * `posix_test` - Simon (`@dumsum`)
+    * `vmm` - Bill (`@dreamliner787-9 `)
+    * `wasm_test` - Simon (`@dumsum`)
+    * `webserver` - Courtney (`@Courtney3141`)
+* `lib`
+    * `fs` - Simon (`@dumsum`)
+    * `libc` - Simon (`@dumsum`)
+    * `firewall` - Courtney (`@Courtney3141`)
+    * `sock` - Simon (`@dumsum`)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,7 +26,7 @@ The default reviewers of the LionsOS are currently
 * `examples/`
     * `fileio` - UNASSIGNED (`@`)
     * `firewall` - Courtney (`@Courtney3141`)
-    * `kitty` - Courtney (`@Courtney3141`)
+    * `kitty` - Bill (`@dreamliner787-9 `)
     * `posix_test` - Simon (`@dumsum`)
     * `vmm` - Bill (`@dreamliner787-9 `)
     * `wasm_test` - Simon (`@dumsum`)


### PR DESCRIPTION
Adding component ownership per meeting. I speculated a bit on some of what the components should be here ... @Ivan-Velickovic your input may be handy.

All of the FS stuff currently doesn't have an obvious owner since it seems like most of it was last touched by James. For CI, I've listed @midnightveil since she is pretty much our official CI wizard now.

@Courtney3141 @dumsum 

