### PR TITLE
posix/file.c: fix stat for root directory

### DIFF
--- a/lib/libc/posix/file.c
+++ b/lib/libc/posix/file.c
@@ -267,6 +267,14 @@ static int file_dup3(int oldfd, int newfd) {
 }
 
 static int fstat_int(const char *path, struct stat *statbuf) {
+    // FatFS rejects "/" with FR_INVALID_NAME, so return a minimal stat for it
+    // here instead of forwarding to the FS server.
+    if (strcmp(path, "/") == 0) {
+        memset(statbuf, 0, sizeof(*statbuf));
+        statbuf->st_mode = S_IFDIR | 0755;
+        return 0;
+    }
+
     ptrdiff_t path_buffer;
     int err = fs_buffer_allocate(&path_buffer);
     if (err) {
@@ -293,12 +301,6 @@ static int fstat_int(const char *path, struct stat *statbuf) {
                                                   } });
 
     fs_buffer_free(path_buffer);
-
-    // FIXME: FS returns this error for "/"
-    if (completion.status == FS_STATUS_INVALID_NAME) {
-        fs_buffer_free(output_buffer);
-        return 0;
-    }
 
     if (completion.status != FS_STATUS_SUCCESS) {
         fs_buffer_free(output_buffer);


### PR DESCRIPTION
Background: FatFS rejects "/" with FR_INVALID_NAME, so `fstat_int` had a stub to return success for a stat call returning this error (FS_STATUS_INVALID_NAME from the FS Server). However, `statbuf` was left unpopulated, so callers potentially read uninitialised memory. 

https://github.com/au-ts/lionsos/pull/321 exposed this latent bug: it broke `wasm_test` because WAMR's WASI preopen registration seemingly couldn't see "/" as a directory (I suspect this just happened to work by chance before the morecore change).

Fix is to populate a minimal stat for "/".