### PR TITLE
included full IPV4 header in ICMP error packets

### DIFF
--- a/examples/firewall/icmp/icmp_module.c
+++ b/examples/firewall/icmp/icmp_module.c
@@ -86,7 +86,7 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
     uint8_t orig_ip_hdr_len = ipv4_header_length(&req->ip_hdr);
     /* Calculate how many bytes of the original packet's data to include  */
     uint16_t orig_pkt_data_len = ntohs(req->ip_hdr.tot_len) - orig_ip_hdr_len;
-    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, orig_pkt_data_len);
+    uint16_t data_to_copy = MIN(FW_ICMP_SRC_DATA_LEN, orig_pkt_data_len);
 
     /* Handle each ICMP type separately */
     switch (req->type) {
@@ -118,7 +118,7 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         * including the unused field, length field, next-hop MTU field,
         * the original IPv4 header, and the accompanying payload.
         */
-        uint16_t icmp_dest_payload_len = 4 + orig_ip_hdr_len + to_copy;
+        uint16_t icmp_dest_payload_len = ICMP_DEST_LEN_NO_IP + orig_ip_hdr_len + data_to_copy;
         ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_COMMON_HDR_LEN + icmp_dest_payload_len);
 
         /* Construct ICMP destination unreachable packet */
@@ -137,7 +137,7 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         }
 
         /* Copy first bytes of data if applicable */
-        memcpy(&icmp_dest->ip_data[orig_ip_hdr_len], req->dest.data, to_copy);
+        memcpy(&icmp_dest->ip_data[orig_ip_hdr_len], req->dest.data, data_to_copy);
         break;
     case ICMP_TTL_EXCEED:
         /* Destination is original packet's source */
@@ -146,7 +146,7 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         /* Calculate the ICMP Time Exceeded packet length,
         * including the unused field, original IPv4 header, and payload.
         */
-        uint16_t icmp_time_exceeded_payload_len = 4 + orig_ip_hdr_len + to_copy;
+        uint16_t icmp_time_exceeded_payload_len = ICMP_TIME_EXCEEDED_LEN_NO_IP + orig_ip_hdr_len + data_to_copy;
         ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_COMMON_HDR_LEN + icmp_time_exceeded_payload_len);
 
         /* Construct ICMP time exceeded packet */
@@ -163,7 +163,7 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         }
 
         /* Copy first bytes of data if applicable */
-        memcpy(&icmp_time_exceeded->ip_data[orig_ip_hdr_len], req->time_exceeded.data, to_copy);
+        memcpy(&icmp_time_exceeded->ip_data[orig_ip_hdr_len], req->time_exceeded.data, data_to_copy);
         break;
     case ICMP_REDIRECT_MSG:
         /* Destination is original packet's source */
@@ -172,7 +172,7 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         /* Calculate the ICMP redirect packet length,
         * including the gateway IP address, original IPv4 header, and payload.
         */
-        uint16_t icmp_redirect_payload_len = 4 + orig_ip_hdr_len + to_copy;
+        uint16_t icmp_redirect_payload_len = ICMP_REDIRECT_LEN_NO_IP + orig_ip_hdr_len + data_to_copy;
         ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_COMMON_HDR_LEN + icmp_redirect_payload_len);
 
         /* Construct ICMP redirect packet */
@@ -189,7 +189,7 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         }
 
         /* Copy first bytes of data if applicable */
-        memcpy(&icmp_redirect->ip_data[orig_ip_hdr_len], req->redirect.data, to_copy);
+        memcpy(&icmp_redirect->ip_data[orig_ip_hdr_len], req->redirect.data, data_to_copy);
         break;
     default:
         return false;

--- a/examples/firewall/icmp/icmp_module.c
+++ b/examples/firewall/icmp/icmp_module.c
@@ -82,7 +82,11 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
     icmp_hdr->type = req->type;
     icmp_hdr->code = req->code;
 
-    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, ntohs(req->ip_hdr.tot_len) - ipv4_header_length(&req->ip_hdr));
+    /* Calculate the actual length of the original IP header*/
+    uint8_t orig_ip_hdr_len = ipv4_header_length(&req->ip_hdr);
+    /* Calculate how many bytes of the original packet's data to include  */
+    uint16_t orig_pkt_data_len = ntohs(req->ip_hdr.tot_len) - orig_ip_hdr_len;
+    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, orig_pkt_data_len);
 
     /* Handle each ICMP type separately */
     switch (req->type) {
@@ -110,8 +114,12 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         /* Destination is original packet's source */
         ip_hdr->dst_ip = req->ip_hdr.src_ip;
 
-        /* Total length of ICMP destination unreachable IP packet */
-        ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_DEST_LEN);
+        /* Calculate the ICMP Destination Unreachable packet length,
+        * including the unused field, length field, next-hop MTU field,
+        * the original IPv4 header, and the accompanying payload.
+        */
+        uint16_t icmp_dest_payload_len = 4 + orig_ip_hdr_len + to_copy;
+        ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_COMMON_HDR_LEN + icmp_dest_payload_len);
 
         /* Construct ICMP destination unreachable packet */
         icmp_dest_t *icmp_dest = (icmp_dest_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET);
@@ -121,18 +129,25 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         icmp_dest->len = 0;
         icmp_dest->nexthop_mtu = 0;
 
-        /* Copy IP header */
-        memcpy(&icmp_dest->ip_hdr, &req->ip_hdr, IPV4_HDR_LEN_MIN);
+        /* Copy entire IP header (minimum + extended options too) */
+        memcpy(&icmp_dest->ip_data, &req->ip_hdr, IPV4_HDR_LEN_MIN);
+        if (orig_ip_hdr_len > IPV4_HDR_LEN_MIN) {
+                 memcpy(&icmp_dest->ip_data[IPV4_HDR_LEN_MIN], &req->ip_hdr_extra,
+                   orig_ip_hdr_len - IPV4_HDR_LEN_MIN);
+        }
 
         /* Copy first bytes of data if applicable */
-        memcpy(&icmp_dest->data, req->dest.data, to_copy);
+        memcpy(&icmp_dest->ip_data[orig_ip_hdr_len], req->dest.data, to_copy);
         break;
     case ICMP_TTL_EXCEED:
         /* Destination is original packet's source */
         ip_hdr->dst_ip = req->ip_hdr.src_ip;
 
-        /* Total length of ICMP time exceeded IP packet */
-        ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_TIME_EXCEEDED_LEN);
+        /* Calculate the ICMP Time Exceeded packet length,
+        * including the unused field, original IPv4 header, and payload.
+        */
+        uint16_t icmp_time_exceeded_payload_len = 4 + orig_ip_hdr_len + to_copy;
+        ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_COMMON_HDR_LEN + icmp_time_exceeded_payload_len);
 
         /* Construct ICMP time exceeded packet */
         icmp_time_exceeded_t *icmp_time_exceeded = (icmp_time_exceeded_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET);
@@ -140,18 +155,25 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         /* Unused must be set to 0 */
         icmp_time_exceeded->unused = 0;
 
-        /* Copy IP header */
-        memcpy(&icmp_time_exceeded->ip_hdr, &req->ip_hdr, IPV4_HDR_LEN_MIN);
+        /* Copy entire IP header (minimum + extended options too)*/
+        memcpy(&icmp_time_exceeded->ip_data, &req->ip_hdr, IPV4_HDR_LEN_MIN);
+        if (orig_ip_hdr_len > IPV4_HDR_LEN_MIN) {
+            memcpy(&icmp_time_exceeded->ip_data[IPV4_HDR_LEN_MIN], &req->ip_hdr_extra,
+                   orig_ip_hdr_len - IPV4_HDR_LEN_MIN);
+        }
 
         /* Copy first bytes of data if applicable */
-        memcpy(&icmp_time_exceeded->data, req->time_exceeded.data, to_copy);
+        memcpy(&icmp_time_exceeded->ip_data[orig_ip_hdr_len], req->time_exceeded.data, to_copy);
         break;
     case ICMP_REDIRECT_MSG:
         /* Destination is original packet's source */
         ip_hdr->dst_ip = req->ip_hdr.src_ip;
 
-        /* Total length of ICMP redicrt IP packet */
-        ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_REDIRECT_LEN);
+        /* Calculate the ICMP redirect packet length,
+        * including the gateway IP address, original IPv4 header, and payload.
+        */
+        uint16_t icmp_redirect_payload_len = 4 + orig_ip_hdr_len + to_copy;
+        ip_hdr->tot_len = htons(IPV4_HDR_LEN_MIN + ICMP_COMMON_HDR_LEN + icmp_redirect_payload_len);
 
         /* Construct ICMP redirect packet */
         icmp_redirect_t *icmp_redirect = (icmp_redirect_t *)(pkt_vaddr + ICMP_PAYLOAD_OFFSET);
@@ -159,10 +181,15 @@ static bool process_icmp_request(icmp_req_t *req, bool *transmitted)
         /* Set the gateway IP address*/
         icmp_redirect->gateway_ip = req->redirect.gateway_ip;
 
-        /* Copy IP header */
-        memcpy(&icmp_redirect->ip_hdr, &req->ip_hdr, IPV4_HDR_LEN_MIN);
+        /* Copy entire IP header (minimum + extended options) */
+        memcpy(&icmp_redirect->ip_data, &req->ip_hdr, IPV4_HDR_LEN_MIN);
+        if (orig_ip_hdr_len > IPV4_HDR_LEN_MIN) {
+            memcpy(&icmp_redirect->ip_data[IPV4_HDR_LEN_MIN], &req->ip_hdr_extra,
+                   orig_ip_hdr_len - IPV4_HDR_LEN_MIN);
+        }
+
         /* Copy first bytes of data if applicable */
-        memcpy(&icmp_redirect->data, req->redirect.data, to_copy);
+        memcpy(&icmp_redirect->ip_data[orig_ip_hdr_len], req->redirect.data, to_copy);
         break;
     default:
         return false;

--- a/include/lions/firewall/icmp.h
+++ b/include/lions/firewall/icmp.h
@@ -87,25 +87,21 @@ typedef struct __attribute__((__packed__)) icmp_dest {
     uint8_t len;
     /* optional MTU of the next-hop network if source packet was too large, or 0 */
     uint16_t nexthop_mtu;
-    /* IP header of source packet */
-    ipv4_hdr_t ip_hdr;
-    /* first 8 bytes of data from source packet */
-    uint8_t data[FW_ICMP_SRC_DATA_LEN];
+    /* IP header (up to 60 bytes) followed by data (up to 8 bytes) */
+    uint8_t ip_data[60 + FW_ICMP_SRC_DATA_LEN];
 } icmp_dest_t;
 
-#define ICMP_DEST_LEN (ICMP_COMMON_HDR_LEN + sizeof(icmp_dest_t))
+#define ICMP_DEST_LEN (ICMP_COMMON_HDR_LEN + 4 + 60 + FW_ICMP_SRC_DATA_LEN)
 
 /* ----------------- 5 - ICMP REDIRECT MSG ---------------------------*/
 typedef struct __attribute__((__packed__)) icmp_redirect {
     /* IP Address of the new path */
     uint32_t gateway_ip;
-    /* IP header of source packet */
-    ipv4_hdr_t ip_hdr;
-    /* First 8 bytes of data from source packet */
-    uint8_t data[FW_ICMP_SRC_DATA_LEN];
+    /* IP header (up to 60 bytes) followed by data (up to 8 bytes) */
+    uint8_t ip_data[60 + FW_ICMP_SRC_DATA_LEN];
 } icmp_redirect_t;
 
-#define ICMP_REDIRECT_LEN (ICMP_COMMON_HDR_LEN + sizeof(icmp_redirect_t))
+#define ICMP_REDIRECT_LEN (ICMP_COMMON_HDR_LEN + 4 + 60 + FW_ICMP_SRC_DATA_LEN)
 
 /* ----------------- 8 - Echo Request / 0 - Echo Reply ---------------------------*/
 typedef struct __attribute__((__packed__)) icmp_echo {
@@ -124,13 +120,11 @@ typedef struct __attribute__((__packed__)) icmp_echo {
 typedef struct __attribute__((__packed__)) icmp_time_exceeded {
     /* unused, must be set to 0 */
     uint32_t unused;
-    /* IP header of source packet */
-    ipv4_hdr_t ip_hdr;
-    /* First 8 bytes of data from source packet */
-    uint8_t data[FW_ICMP_SRC_DATA_LEN];
+    /* IP header (up to 60 bytes) followed by data (up to 8 bytes)*/
+    uint8_t ip_data[60 + FW_ICMP_SRC_DATA_LEN];
 } icmp_time_exceeded_t;
 
-#define ICMP_TIME_EXCEEDED_LEN (ICMP_COMMON_HDR_LEN + sizeof(icmp_time_exceeded_t))
+#define ICMP_TIME_EXCEEDED_LEN (ICMP_COMMON_HDR_LEN + 4 + 60 + FW_ICMP_SRC_DATA_LEN)
 
 /* ----------------- Firewall Data Types (Internal Use) --------------------------- */
 
@@ -178,6 +172,7 @@ typedef struct icmp_req {
     eth_hdr_t eth_hdr;
     /* header of source IP packet */
     ipv4_hdr_t ip_hdr;
+    uint32_t ip_hdr_extra[31];
     /* Type-specific data */
     union {
         icmp_req_dest_t dest;
@@ -226,6 +221,9 @@ static inline bool icmp_enqueue_error(fw_queue_t *icmp_queue, uint8_t type, uint
     /* Copy IP header into ICMP request */
     ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
     memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
+    if (ipv4_header_length(ip_hdr) > IPV4_HDR_LEN_MIN) {
+        memcpy(&req.ip_hdr_extra, (void *)ip_hdr + IPV4_HDR_LEN_MIN, ipv4_header_length(ip_hdr) - IPV4_HDR_LEN_MIN);
+    }
 
     /* Copy first bytes of data if applicable */
     uint8_t ip_hdr_len = ipv4_header_length(ip_hdr);
@@ -304,6 +302,10 @@ static inline int icmp_enqueue_redirect(fw_queue_t *icmp_queue, uint8_t code, ui
     /* Copy IP header into ICMP request */
     ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
     memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
+    if (ipv4_header_length(ip_hdr) > IPV4_HDR_LEN_MIN) {
+        memcpy(&req.ip_hdr_extra, (void *)ip_hdr + IPV4_HDR_LEN_MIN,
+               ipv4_header_length(ip_hdr) - IPV4_HDR_LEN_MIN);
+    }
 
     /* Set gateway IP and copy first bytes of data */
     req.redirect.gateway_ip = gateway_ip;

--- a/include/lions/firewall/icmp.h
+++ b/include/lions/firewall/icmp.h
@@ -88,20 +88,16 @@ typedef struct __attribute__((__packed__)) icmp_dest {
     /* optional MTU of the next-hop network if source packet was too large, or 0 */
     uint16_t nexthop_mtu;
     /* IP header (up to 60 bytes) followed by data (up to 8 bytes) */
-    uint8_t ip_data[60 + FW_ICMP_SRC_DATA_LEN];
+    uint8_t ip_data[IPV4_HDR_LEN_MAX + FW_ICMP_SRC_DATA_LEN];
 } icmp_dest_t;
-
-#define ICMP_DEST_LEN (ICMP_COMMON_HDR_LEN + 4 + 60 + FW_ICMP_SRC_DATA_LEN)
 
 /* ----------------- 5 - ICMP REDIRECT MSG ---------------------------*/
 typedef struct __attribute__((__packed__)) icmp_redirect {
     /* IP Address of the new path */
     uint32_t gateway_ip;
     /* IP header (up to 60 bytes) followed by data (up to 8 bytes) */
-    uint8_t ip_data[60 + FW_ICMP_SRC_DATA_LEN];
+    uint8_t ip_data[IPV4_HDR_LEN_MAX + FW_ICMP_SRC_DATA_LEN];
 } icmp_redirect_t;
-
-#define ICMP_REDIRECT_LEN (ICMP_COMMON_HDR_LEN + 4 + 60 + FW_ICMP_SRC_DATA_LEN)
 
 /* ----------------- 8 - Echo Request / 0 - Echo Reply ---------------------------*/
 typedef struct __attribute__((__packed__)) icmp_echo {
@@ -121,10 +117,17 @@ typedef struct __attribute__((__packed__)) icmp_time_exceeded {
     /* unused, must be set to 0 */
     uint32_t unused;
     /* IP header (up to 60 bytes) followed by data (up to 8 bytes)*/
-    uint8_t ip_data[60 + FW_ICMP_SRC_DATA_LEN];
+    uint8_t ip_data[IPV4_HDR_LEN_MAX + FW_ICMP_SRC_DATA_LEN];
 } icmp_time_exceeded_t;
 
-#define ICMP_TIME_EXCEEDED_LEN (ICMP_COMMON_HDR_LEN + 4 + 60 + FW_ICMP_SRC_DATA_LEN)
+/* Length of icmp_dest_t fields preceding the IP header and data */
+#define ICMP_DEST_LEN_NO_IP (sizeof(icmp_dest_t) - (IPV4_HDR_LEN_MAX + FW_ICMP_SRC_DATA_LEN))
+
+/* Length of icmp_time_exceeded_t fields preceding the IP header and data */
+#define ICMP_TIME_EXCEEDED_LEN_NO_IP (sizeof(icmp_time_exceeded_t) - (IPV4_HDR_LEN_MAX + FW_ICMP_SRC_DATA_LEN))
+
+/* Length of icmp_redirect_t fields preceding the IP header and data */
+#define ICMP_REDIRECT_LEN_NO_IP (sizeof(icmp_redirect_t) - (IPV4_HDR_LEN_MAX + FW_ICMP_SRC_DATA_LEN))
 
 /* ----------------- Firewall Data Types (Internal Use) --------------------------- */
 
@@ -172,7 +175,7 @@ typedef struct icmp_req {
     eth_hdr_t eth_hdr;
     /* header of source IP packet */
     ipv4_hdr_t ip_hdr;
-    uint32_t ip_hdr_extra[31];
+    uint8_t ip_hdr_extra[IPV4_HDR_LEN_MAX - IPV4_HDR_LEN_MIN];
     /* Type-specific data */
     union {
         icmp_req_dest_t dest;
@@ -220,15 +223,16 @@ static inline bool icmp_enqueue_error(fw_queue_t *icmp_queue, uint8_t type, uint
 
     /* Copy IP header into ICMP request */
     ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
+    uint8_t ip_hdr_len = ipv4_header_length(ip_hdr);
+
     memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
-    if (ipv4_header_length(ip_hdr) > IPV4_HDR_LEN_MIN) {
-        memcpy(&req.ip_hdr_extra, (void *)ip_hdr + IPV4_HDR_LEN_MIN, ipv4_header_length(ip_hdr) - IPV4_HDR_LEN_MIN);
+    if (ip_hdr_len > IPV4_HDR_LEN_MIN) {
+        memcpy(&req.ip_hdr_extra, (void *)ip_hdr + IPV4_HDR_LEN_MIN, ip_hdr_len - IPV4_HDR_LEN_MIN);
     }
 
     /* Copy first bytes of data if applicable */
-    uint8_t ip_hdr_len = ipv4_header_length(ip_hdr);
-    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(ip_hdr->tot_len) - ip_hdr_len);
-    memcpy(req.dest.data, (void *)(pkt_vaddr + transport_layer_offset(ip_hdr)), to_copy);
+    uint16_t data_to_copy = MIN(FW_ICMP_SRC_DATA_LEN, ntohs(ip_hdr->tot_len) - ip_hdr_len);
+    memcpy(req.dest.data, (void *)(pkt_vaddr + transport_layer_offset(ip_hdr)), data_to_copy);
 
     return fw_enqueue(icmp_queue, &req) == 0;
 }
@@ -252,7 +256,7 @@ static inline bool icmp_enqueue_echo_reply(fw_queue_t *icmp_queue, uintptr_t pkt
     uint16_t echo_seq = ntohs(echo_hdr->seq);
 
     /* Calculate payload length */
-    uint16_t icmp_total_len = htons(ip_hdr->tot_len) - ipv4_header_length(ip_hdr);
+    uint16_t icmp_total_len = ntohs(ip_hdr->tot_len) - ipv4_header_length(ip_hdr);
     uint16_t payload_len = icmp_total_len - ICMP_COMMON_HDR_LEN - offsetof(icmp_echo_t, data);
     if (payload_len > FW_ICMP_ECHO_PAYLOAD_LEN) {
         payload_len = FW_ICMP_ECHO_PAYLOAD_LEN;
@@ -301,16 +305,18 @@ static inline int icmp_enqueue_redirect(fw_queue_t *icmp_queue, uint8_t code, ui
 
     /* Copy IP header into ICMP request */
     ipv4_hdr_t *ip_hdr = (ipv4_hdr_t *)(pkt_vaddr + IPV4_HDR_OFFSET);
+    uint8_t ip_hdr_len = ipv4_header_length(ip_hdr);
+
     memcpy(&req.ip_hdr, (void *)ip_hdr, IPV4_HDR_LEN_MIN);
-    if (ipv4_header_length(ip_hdr) > IPV4_HDR_LEN_MIN) {
+    if (ip_hdr_len > IPV4_HDR_LEN_MIN) {
         memcpy(&req.ip_hdr_extra, (void *)ip_hdr + IPV4_HDR_LEN_MIN,
-               ipv4_header_length(ip_hdr) - IPV4_HDR_LEN_MIN);
+            ip_hdr_len - IPV4_HDR_LEN_MIN);
     }
 
     /* Set gateway IP and copy first bytes of data */
     req.redirect.gateway_ip = gateway_ip;
-    uint16_t to_copy = MIN(FW_ICMP_SRC_DATA_LEN, htons(ip_hdr->tot_len) - ipv4_header_length(ip_hdr));
-    memcpy(req.redirect.data, (void *)(pkt_vaddr + transport_layer_offset(ip_hdr)), to_copy);
+    uint16_t data_to_copy = MIN(FW_ICMP_SRC_DATA_LEN, ntohs(ip_hdr->tot_len) - ip_hdr_len);
+    memcpy(req.redirect.data, (void *)(pkt_vaddr + transport_layer_offset(ip_hdr)), data_to_copy);
 
     return fw_enqueue(icmp_queue, &req);
 }

--- a/include/lions/firewall/ip.h
+++ b/include/lions/firewall/ip.h
@@ -58,6 +58,9 @@ typedef struct __attribute__((__packed__)) ipv4_hdr {
 /* Length of IPv4 header with no optional fields */
 #define IPV4_HDR_LEN_MIN sizeof(ipv4_hdr_t)
 
+/* Maximum length of an IPv4 header including options */
+#define IPV4_HDR_LEN_MAX 60
+
 /* IPv4 differentiated services code point values */
 #define IPV4_DSCP_NET_CTRL 48 /* Network control */
 


### PR DESCRIPTION
This PR updates the ICMP module so that the ICMP packets it generates now include the full IPv4 header. This improves packet completeness and works to ensurethe generated ICMP messages better match the expected network behavior described in issue #315.

Fixes #315