### PR TITLE
Fixed broken i2c error handling, use exception types instead

### DIFF
--- a/components/micropython/machine_i2c.c
+++ b/components/micropython/machine_i2c.c
@@ -193,22 +193,20 @@ static int machine_i2c_transfer_single(mp_obj_base_t *obj, uint16_t addr, size_t
     if (err != I2C_ERR_OK) {
         switch (err) {
         case I2C_ERR_QUEUE:
-            return -MP_EFAULT;
-
         case I2C_ERR_MALFORMED_TRANSACTION:
         case I2C_ERR_MALFORMED_HEADER:
-            // Internal error.
-            return -MP_EIO;
+            // Misusing I2C protocol, fatal.
+            return -MP_EFAULT;
 
         case I2C_ERR_UNPERMITTED_ADDR:
             return -MP_EACCES;
         case I2C_ERR_TIMEOUT:
-        case I2C_ERR_NACK:
             return -MP_ETIMEDOUT;
 
         case I2C_ERR_NOREAD:
         case I2C_ERR_BADSEQ:
         case I2C_ERR_OTHER:
+        case I2C_ERR_NACK:
         default:
             return -MP_EIO;
         }

--- a/examples/kitty/client/pn532.py
+++ b/examples/kitty/client/pn532.py
@@ -90,7 +90,7 @@ class PN532:
             try:
                 data = self.i2c_bus.readfrom(_PN532_I2C_BUS_ADDRESS, _PN532_ACK_FRAME_SIZE)
             except OSError as e:
-                if e.errno is errno.EIO:
+                if e.errno == errno.EIO:
                     continue    # NACK probably, retry
                 raise e
             if len(data) and data[0] & 1:
@@ -117,7 +117,7 @@ class PN532:
             try:
                 data = self.i2c_bus.readfrom(_PN532_I2C_BUS_ADDRESS, 6)
             except OSError as e:
-                if e.errno is errno.EIO:
+                if e.errno == errno.EIO:
                     continue    # NACK probably, retry
                 raise e
             if (data[0] & 1):

--- a/examples/kitty/client/pn532.py
+++ b/examples/kitty/client/pn532.py
@@ -4,6 +4,7 @@
 # We must ignore these imports since they are not available in a normal Python
 # environment where we do the type checking
 from machine import I2C # type: ignore
+import errno
 from time import sleep_ms # type: ignore
 import sys
 
@@ -86,7 +87,12 @@ class PN532:
     def _pn532_read_ack_frame(self, retries: int) -> bool:
         attempts = 0
         while (attempts < retries):
-            data = self.i2c_bus.readfrom(_PN532_I2C_BUS_ADDRESS, _PN532_ACK_FRAME_SIZE)
+            try:
+                data = self.i2c_bus.readfrom(_PN532_I2C_BUS_ADDRESS, _PN532_ACK_FRAME_SIZE)
+            except OSError as e:
+                if e.errno is errno.EIO:
+                    continue    # NACK probably, retry
+                raise e
             if len(data) and data[0] & 1:
                 for i in range(0, _PN532_ACK_FRAME_SIZE - 1):
                     value = data[i + 1]
@@ -108,8 +114,12 @@ class PN532:
         attempts = 0
 
         while True:
-            data = self.i2c_bus.readfrom(_PN532_I2C_BUS_ADDRESS, 6)
-
+            try:
+                data = self.i2c_bus.readfrom(_PN532_I2C_BUS_ADDRESS, 6)
+            except OSError as e:
+                if e.errno is errno.EIO:
+                    continue    # NACK probably, retry
+                raise e
             if (data[0] & 1):
                 length = data[4]
                 break


### PR DESCRIPTION
Closes #336 

Our error handling was borked for i2c. We now use proper exception handling to catch the types that prompt us to retry. This changes error codes to distinguish clearly between bus and sDDF errors, where bus errors are EIO.