### PR TITLE
kitty: fix stray spaces in payload to server

### DIFF
--- a/examples/kitty/client/kitty.py
+++ b/examples/kitty/client/kitty.py
@@ -115,7 +115,7 @@ async def on_tap(card_id):
         try:
             info(f'card id: {card_id}')
             writer_stream.write(
-                bytes(f'100 {token} {''.join('{: 02x}'.format(x) for x in card_id)} 1.0' + '\n', 'utf-8')
+                bytes(f'100 {token} {''.join('{:02x}'.format(x) for x in card_id)} 1.0' + '\n', 'utf-8')
             )
             await writer_stream.drain()
             break


### PR DESCRIPTION
Fixes the Kitty server crashing:
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/opt/billn/lionsos/examples/kitty/server/server.py", line 228, in run
    handle_connection(self.conn, self.sock)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/billn/lionsos/examples/kitty/server/server.py", line 188, in handle_connection
    (cardno, ser_value) = payload.split(b' ')
    ^^^^^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2, got 9)

This space was introduced in commit 5210d04ba12af191ed0d05163f6921e13ca441a5, I'm not sure why...